### PR TITLE
DOMAIN_NAME in Twilio Functions does not include https://

### DIFF
--- a/src/route.js
+++ b/src/route.js
@@ -17,7 +17,7 @@ function constructContext({ url, env }) {
   function getTwilioClient() {
     return twilio(process.env.ACCOUNT_SID, process.env.AUTH_TOKEN);
   }
-  const DOMAIN_NAME = url;
+  const DOMAIN_NAME = url.replace(/^https?:\/\//, '');
   return { ...env, DOMAIN_NAME, getTwilioClient };
 }
 

--- a/src/route.test.js
+++ b/src/route.test.js
@@ -117,7 +117,7 @@ describe('constructContext function', () => {
       }
     };
     const context = constructContext(config);
-    expect(context.DOMAIN_NAME).toBe('http://localhost:8000');
+    expect(context.DOMAIN_NAME).toBe('localhost:8000');
     expect(context.ACCOUNT_SID).toBe('ACxxxxxxxxxxx');
     expect(context.AUTH_TOKEN).toBe('xyz');
     expect(typeof context.getTwilioClient).toBe('function');


### PR DESCRIPTION
Create the following in a twilio function to see what I mean:

exports.handler = function(context, event, callback) {
	callback(null, context.DOMAIN_NAME);
};
