### PR TITLE
fix(runtime): delete application files from require cache on page load in live mode

### DIFF
--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -37,6 +37,10 @@ function requireCacheCleaner(
 ) {
   debug('Deleting require cache');
   Object.keys(require.cache).forEach(key => {
+    // Entries in the cache that end with .node are compiled binaries, deleting
+    // those has unspecified results, so we keep them.
+    // Entries in the cache that include "twilio-run" are part of this module
+    // or its dependencies, so don't need to be cleared.
     if (!(key.endsWith('.node') || key.includes('twilio-run'))) {
       delete require.cache[key];
     }


### PR DESCRIPTION
This middleware will delete items from the cache that are not native extensions (cache key ends in ".node") or part of the twilio-run platform on every request when the server is in live mode.

Fixes #108.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
