### PR TITLE
fix(shared): update description text for auth env field overrides

### DIFF
--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -54,12 +54,12 @@ export const sharedApiRelatedCliOptions: { [key: string]: Options } = {
     type: 'string',
     alias: 'u',
     describe:
-      'A specific account SID to be used for deployment. Uses fields in .env otherwise',
+      'A specific account SID to be used for deployment. Uses ACCOUNT_SID field in .env otherwise',
   },
   'auth-token': {
     type: 'string',
     describe:
-      'Use a specific auth token for deployment. Uses fields from .env otherwise',
+      'Use a specific auth token for deployment. Uses AUTH_TOKEN field from .env otherwise',
   },
   'load-system-env': {
     default: false,


### PR DESCRIPTION
I got confused by what variables were and weren't being used to authenticate API calls. More specificity in these descriptions would have been helpful.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
