### PR TITLE
fix(serverless-api): retries on 429 error for POST request

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "parser": "typescript"
+}

--- a/packages/serverless-api/src/client.ts
+++ b/packages/serverless-api/src/client.ts
@@ -259,7 +259,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
           this
         );
         const foundFunction = availableFunctions.find(
-          (fn) => fn.friendly_name === filterByFunction
+          fn => fn.friendly_name === filterByFunction
         );
         if (!foundFunction) {
           throw new Error('Invalid Function Name or SID');
@@ -297,7 +297,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
           this
         );
         const foundFunction = availableFunctions.find(
-          (fn) => fn.friendly_name === filterByFunction
+          fn => fn.friendly_name === filterByFunction
         );
         if (!foundFunction) {
           throw new Error('Invalid Function Name or SID');
@@ -506,7 +506,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
         message: `Uploading ${functions.length} Functions`,
       });
       const functionVersions = await Promise.all(
-        functionResources.map((fn) => {
+        functionResources.map(fn => {
           return uploadFunction(fn, serviceSid as string, this, this.config);
         })
       );
@@ -530,7 +530,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
         message: `Uploading ${assets.length} Assets`,
       });
       const assetVersions = await Promise.all(
-        assetResources.map((asset) => {
+        assetResources.map(asset => {
           return uploadAsset(asset, serviceSid as string, this, this.config);
         })
       );
@@ -662,6 +662,8 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
   ): Promise<unknown> {
     options.retry = {
       limit: this.config.retryLimit || RETRY_LIMIT,
+      methods: ['GET', 'POST', 'DELETE'],
+      statusCodes: [429],
     };
     return this.limit(() => this.client[method](path, options));
   }


### PR DESCRIPTION
Got by default does not retry on POST requests. This changes the retry behaviour to retry across all of the methods that the API uses (GET, POST and DELETE) but only for 429 errors.

Excuse all the other changes, I think they came from the linter during commit. The important lines (right at the bottom) are: 

```diff
    options.retry = {
      limit: this.config.retryLimit || RETRY_LIMIT,
+     methods: ["GET", "POST", "DELETE"],
+     statusCodes: [429]
    };
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
