### PR TITLE
fix(debugger): fixes debugger redaction in plugin-serverless

### DIFF
--- a/packages/twilio-run/src/cli.ts
+++ b/packages/twilio-run/src/cli.ts
@@ -6,7 +6,6 @@ import * as NewCommand from './commands/new';
 import * as StartCommand from './commands/start';
 import * as ListTemplatesCommand from './commands/list-templates';
 import * as LogsCommand from './commands/logs';
-import './utils/debug';
 
 export async function run(rawArgs: string[]) {
   yargs

--- a/packages/twilio-run/src/index.ts
+++ b/packages/twilio-run/src/index.ts
@@ -1,4 +1,2 @@
-import './utils/debug';
-
 export { functionToRoute as handlerToExpressRoute } from './runtime/route';
 export { runServer as runDevServer } from './runtime/server';

--- a/packages/twilio-run/src/utils/debug.ts
+++ b/packages/twilio-run/src/utils/debug.ts
@@ -77,3 +77,5 @@ debug.formatters.r = function redactedFormatterSameline(v: any): string {
   }
   return debug.formatters.o.bind(debug)(v);
 };
+
+export default debug;

--- a/packages/twilio-run/src/utils/logger.ts
+++ b/packages/twilio-run/src/utils/logger.ts
@@ -1,5 +1,5 @@
 import { ClientApiError } from '@twilio-labs/serverless-api/dist/utils/error';
-import debug from 'debug';
+import debug from './debug';
 import ora from 'ora';
 import { Writable } from 'stream';
 import terminalLink from 'terminal-link';


### PR DESCRIPTION
Fixes #185.

When using the twilio-run debugger within the serverless plugin, redaction wasn't working. I thought this might be because the debug module was being overwritten. Looking at where the formatters are added, the resultant debug object was never exported and used.

Exporting this debugger and explicitly using it brought the formatter back in the plugin.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
