### PR TITLE
Fix log tailing

### DIFF
--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -1,6 +1,6 @@
-const path = require("path");
-const camelCase = require("lodash.camelcase");
-const { flags } = require("@oclif/command");
+const path = require('path');
+const camelCase = require('lodash.camelcase');
+const { flags } = require('@oclif/command');
 
 function convertYargsOptionsToOclifFlags(options) {
   const flagsResult = Object.keys(options).reduce((result, name) => {
@@ -11,14 +11,19 @@ function convertYargsOptionsToOclifFlags(options) {
       hidden: opt.hidden,
     };
 
-    if (typeof opt.default !== "undefined") {
+    if (typeof opt.default !== 'undefined') {
       flag.default = opt.default;
 
-      if (opt.type === "boolean") {
+      if (opt.type === 'boolean') {
         if (flag.default === true) {
           flag.allowNo = true;
         }
       }
+    }
+
+    if (opt.type === 'number') {
+      opt.type = 'string';
+      flag.parse = input => parseFloat(input);
     }
 
     if (opt.alias) {
@@ -37,7 +42,7 @@ function convertYargsOptionsToOclifFlags(options) {
 
 function normalizeFlags(flags) {
   const result = Object.keys(flags).reduce((current, name) => {
-    if (name.includes("-")) {
+    if (name.includes('-')) {
       const normalizedName = camelCase(name);
       current[normalizedName] = flags[name];
     }

--- a/packages/serverless-api/src/streams/logs.ts
+++ b/packages/serverless-api/src/streams/logs.ts
@@ -9,6 +9,7 @@ export class LogsStream extends Readable {
   private _pollingCacheSize: number;
   private _interval: NodeJS.Timeout | undefined;
   private _viewedSids: Set<Sid>;
+  private _viewedLogs: Array<{ sid: Sid; dateCreated: Date }>;
 
   constructor(
     private environmentSid: Sid,
@@ -19,6 +20,7 @@ export class LogsStream extends Readable {
     super({ objectMode: true });
     this._interval = undefined;
     this._viewedSids = new Set();
+    this._viewedLogs = [];
     this._pollingFrequency = config.pollingFrequency || 1000;
     this._pollingCacheSize = config.logCacheSize || 1000;
   }
@@ -54,13 +56,35 @@ export class LogsStream extends Readable {
       // The logs endpoint is not reliably returning logs in the same order
       // Therefore we need to keep a set of all previously seen log entries
       // In order to avoid memory leaks we cap the total size of logs at 1000
-      // If the new set is larger we'll instead only use the SIDs from the current
-      // request.
-      if (logs.length + this._viewedSids.size <= this._pollingCacheSize) {
-        logs.map(log => log.sid).forEach(sid => this._viewedSids.add(sid));
-      } else {
-        this._viewedSids = new Set(logs.map(log => log.sid));
-      }
+      // (or the set pollingCacheSize).
+      //
+      // We store an array of the logs' SIDs and created dates.
+      // Then when a new page of logs is added, we find the unique logs, sort by
+      // date created, newest to oldest, and chop off the end of the array (the
+      // oldest logs) leaving the most recent logs in memory. We then turn that
+      // into a set of SIDs to check against next time.
+
+      // Creates a unique set of log sids and date created from previous logs
+      // and new logs by stringifying the sid and the date together.
+      const viewedLogsSet = new Set([
+        ...this._viewedLogs.map(
+          log => `${log.sid}-${log.dateCreated.toISOString()}`
+        ),
+        ...logs.map(log => `${log.sid}-${log.date_created}`),
+      ]);
+      // Then we take that set, map over the logs and split them up into sid and
+      // date again, sort them most to least recent and chop off the oldest if
+      // they are beyond the polling cache size.
+      this._viewedLogs = [...viewedLogsSet]
+        .map(logString => {
+          const [sid, dateCreated] = logString.split('-');
+          return { sid, dateCreated: new Date(dateCreated) };
+        })
+        .sort((a, b) => b.dateCreated.valueOf() - a.dateCreated.valueOf())
+        .slice(0, this._pollingCacheSize);
+      // Finally we create a set of just SIDs to compare against.
+      this._viewedSids = new Set(this._viewedLogs.map(log => log.sid));
+
       if (!this.config.tail) {
         this.push(null);
       }
@@ -70,10 +94,12 @@ export class LogsStream extends Readable {
   }
 
   _read() {
-    if (this.config.tail && !this._interval) {
-      this._interval = setInterval(() => {
-        this._poll();
-      }, this._pollingFrequency);
+    if (this.config.tail) {
+      if (!this._interval) {
+        this._interval = setInterval(() => {
+          this._poll();
+        }, this._pollingFrequency);
+      }
     } else {
       this._poll();
     }

--- a/packages/serverless-api/src/types/logs.ts
+++ b/packages/serverless-api/src/types/logs.ts
@@ -9,6 +9,7 @@ export type LogsConfig = {
   limit?: number;
   filterByFunction?: string | Sid;
   pollingFrequency?: number;
+  logCacheSize?: number;
 };
 
 export type LogFilters = {

--- a/packages/twilio-run/src/commands/logs.ts
+++ b/packages/twilio-run/src/commands/logs.ts
@@ -112,6 +112,12 @@ export const cliInfo: CliInfo = {
       describe:
         'Path to .env file for environment variables that should be installed',
     },
+    'log-cache-size': {
+      type: 'number',
+      hidden: true,
+      describe:
+        'Tailing the log endpoint will cache previously seen entries to avoid duplicates. The cache is topped at a maximum of 1000 by default. This option can change that.',
+    },
   },
 };
 

--- a/packages/twilio-run/src/config/logs.ts
+++ b/packages/twilio-run/src/config/logs.ts
@@ -32,6 +32,7 @@ export type LogsCliFlags = Arguments<
     functionSid?: string;
     tail: boolean;
     outputFormat?: string;
+    logCacheSize?: number;
   }
 >;
 
@@ -81,5 +82,6 @@ export async function getConfigFromFlags(
     tail: flags.tail,
     region,
     edge,
+    logCacheSize: flags.logCacheSize,
   };
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

It appears that the logs endpoint of the Serverless API doesn't always return predictable results, meaning at times we get empty pages on requests, followed by populated ones upon the next one. That might cause the rendering of duplicate logs. While the long term fix should probably be on the API side, this should fix it on the client side.

Instead of clearing the cache of already seen SIDs upon every page request, we'll cache them until we hit a certain defined limit (default 1000). That should reduce the risk of duplicate logs.

**Note:** logs that were executed directly after each other might still appear out of order. This is a limitation of the logging infrastructure.

Since I wasn't able to reproduce the initial issue, I ended up publishing a version of this fix under the canary tag. You can install it through:

```bash
twilio plugins:remove @twilio-labs/plugin-serverless
twilio plugins:install @twilio-labs/plugin-serverless@canary
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
