### PR TITLE
fix(serverless-api): explicitly enable credentials

### DIFF
--- a/packages/serverless-api/src/api/services.ts
+++ b/packages/serverless-api/src/api/services.ts
@@ -1,10 +1,10 @@
 /** @module @twilio-labs/serverless-api/dist/api */
 
 import debug from 'debug';
-import { ServiceList, ServiceResource, Sid } from '../types';
 import { TwilioServerlessApiClient } from '../client';
-import { getPaginatedResource } from './utils/pagination';
+import { ServiceList, ServiceResource, Sid } from '../types';
 import { ClientApiError } from '../utils/error';
+import { getPaginatedResource } from './utils/pagination';
 
 const log = debug('twilio-serverless-api:services');
 
@@ -25,7 +25,7 @@ export async function createService(
       form: {
         UniqueName: serviceName,
         FriendlyName: serviceName,
-        IncludeCrendentials: true,
+        IncludeCredentials: true,
       },
     });
     const service = (resp.body as unknown) as ServiceResource;


### PR DESCRIPTION
<!-- Describe your Pull Request -->

I had a typo in the IncludeCredentials. This still worked because the default is true but we want to make sure to explicitly set it

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
