### PR TITLE
docs: fix typo, executioin -> execution

### DIFF
--- a/packages/plugin-serverless/README.md
+++ b/packages/plugin-serverless/README.md
@@ -343,7 +343,7 @@ OPTIONS
 
   --inspect=inspect                    Enables Node.js debugging protocol
 
-  --inspect-brk=inspect-brk            Enables Node.js debugging protocol, stops executioin until debugger is attached
+  --inspect-brk=inspect-brk            Enables Node.js debugging protocol, stops execution until debugger is attached
 
   --legacy-mode                        Enables legacy mode, it will prefix your asset paths with /assets
 

--- a/packages/twilio-run/src/commands/start.ts
+++ b/packages/twilio-run/src/commands/start.ts
@@ -171,7 +171,7 @@ export const cliInfo: CliInfo = {
     'inspect-brk': {
       type: 'string',
       describe:
-        'Enables Node.js debugging protocol, stops executioin until debugger is attached',
+        'Enables Node.js debugging protocol, stops execution until debugger is attached',
     },
     'legacy-mode': {
       type: 'boolean',


### PR DESCRIPTION
Fixed a typo in readme/docs. Not sure how much of this is code-gen'd from other sources, unfortunately, since the two instances I fixed are of the same copy.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
