### PR TITLE
feat(create-twilio-function): adds twilio to default package.json

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/create-files.js
+++ b/packages/create-twilio-function/src/create-twilio-function/create-files.js
@@ -19,8 +19,11 @@ async function createFile(fullPath, content) {
   return writeFile(fullPath, content, { flag: 'wx' });
 }
 
-const javaScriptDeps = {};
-const typescriptDeps = { '@twilio-labs/serverless-runtime-types': versions.serverlessRuntimeTypes };
+const javaScriptDeps = { twilio: versions.twilio };
+const typescriptDeps = {
+  '@twilio-labs/serverless-runtime-types': versions.serverlessRuntimeTypes,
+  ...javaScriptDeps,
+};
 const javaScriptDevDeps = { 'twilio-run': versions.twilioRun };
 const typescriptDevDeps = {
   'twilio-run': versions.twilioRun,
@@ -38,11 +41,14 @@ function createPackageJSON(pathName, name, projectType = 'javascript') {
   if (projectType === 'typescript') {
     scripts.test = 'tsc --noEmit';
     scripts.build = 'tsc && npm run build:copy-assets';
-    scripts['build:copy-assets'] = 'copyfiles src/assets/* src/assets/**/* --up 2 --exclude **/*.ts dist/assets/';
+    scripts['build:copy-assets'] =
+      'copyfiles src/assets/* src/assets/**/* --up 2 --exclude **/*.ts dist/assets/';
     scripts.prestart = 'npm run build';
     scripts.predeploy = 'npm run build';
-    scripts.start += ' --functions-folder dist/functions --assets-folder dist/assets';
-    scripts.deploy += ' --functions-folder dist/functions --assets-folder dist/assets';
+    scripts.start +=
+      ' --functions-folder dist/functions --assets-folder dist/assets';
+    scripts.deploy +=
+      ' --functions-folder dist/functions --assets-folder dist/assets';
   }
   const packageJSON = JSON.stringify(
     {
@@ -50,35 +56,44 @@ function createPackageJSON(pathName, name, projectType = 'javascript') {
       version: '0.0.0',
       private: true,
       scripts,
-      dependencies: projectType === 'typescript' ? typescriptDeps : javaScriptDeps,
-      devDependencies: projectType === 'typescript' ? typescriptDevDeps : javaScriptDevDeps,
+      dependencies:
+        projectType === 'typescript' ? typescriptDeps : javaScriptDeps,
+      devDependencies:
+        projectType === 'typescript' ? typescriptDevDeps : javaScriptDevDeps,
       engines: { node: versions.node },
     },
     null,
-    2,
+    2
   );
   return createFile(fullPath, packageJSON);
 }
 
 function copyRecursively(src, dest) {
-  return readdir(src).then((children) => {
+  return readdir(src).then(children => {
     return Promise.all(
-      children.map((child) =>
-        stat(path.join(src, child)).then((stats) => {
+      children.map(child =>
+        stat(path.join(src, child)).then(stats => {
           if (stats.isDirectory()) {
             return mkdir(path.join(dest, child)).then(() =>
-              copyRecursively(path.join(src, child), path.join(dest, child)),
+              copyRecursively(path.join(src, child), path.join(dest, child))
             );
           }
-          return copyFile(path.join(src, child), path.join(dest, child), COPYFILE_EXCL);
-        }),
-      ),
+          return copyFile(
+            path.join(src, child),
+            path.join(dest, child),
+            COPYFILE_EXCL
+          );
+        })
+      )
     );
   });
 }
 
 function createExampleFromTemplates(pathName, projectType = 'javascript') {
-  return copyRecursively(path.join(__dirname, '..', '..', 'templates', projectType), pathName);
+  return copyRecursively(
+    path.join(__dirname, '..', '..', 'templates', projectType),
+    pathName
+  );
 }
 
 function createEnvFile(pathName, { accountSid, authToken }) {
@@ -111,8 +126,8 @@ function createTsconfigFile(pathName) {
         },
       },
       null,
-      2,
-    ),
+      2
+    )
   );
 }
 

--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -1,4 +1,5 @@
 module.exports = {
+  twilio: '^3.56',
   twilioRun: '^2.6.0',
   node: '10',
   typescript: '^3.8',

--- a/packages/create-twilio-function/tests/create-files.test.js
+++ b/packages/create-twilio-function/tests/create-files.test.js
@@ -78,6 +78,7 @@ describe('create-files', () => {
       expect(packageJSON.devDependencies['twilio-run']).toEqual(
         versions.twilioRun
       );
+      expect(packageJSON.dependencies['twilio']).toEqual(versions.twilio);
       cleanUp();
     });
 
@@ -103,6 +104,7 @@ describe('create-files', () => {
       expect(
         packageJSON.dependencies['@twilio-labs/serverless-runtime-types']
       ).toEqual(versions.serverlessRuntimeTypes);
+      expect(packageJSON.dependencies['twilio']).toEqual(versions.twilio);
       cleanUp();
     });
     test('it rejects if there is already a package.json', async () => {

--- a/packages/serverless-runtime-types/package.json
+++ b/packages/serverless-runtime-types/package.json
@@ -29,6 +29,7 @@
     "twilio": "^3.33.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.11",
     "all-contributors-cli": "^6.7.0"
   },
   "publishConfig": {


### PR DESCRIPTION
When installing `twilio-run` as a devDependency of a local function repo you get the latest version of `twilio` installed. Deploying that function will then use the default version of `twilio` in Functions which is falling further and further behind. This update adds `twilio` as a direct dependency and installs the latest version allowing developers to see the dependency, understand the version and use their functions locally and deployed with confidence.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
