### PR TITLE
HTTP Agent for proxy

### DIFF
--- a/packages/serverless-api/README.md
+++ b/packages/serverless-api/README.md
@@ -79,6 +79,10 @@ export TWILIO_SERVERLESS_API_CONCURRENCY=1
 export TWILIO_SERVERLESS_API_RETRY_LIMIT=0
 ```
 
+### Usage with proxy
+
+ - `HTTP_PROXY`: If deploying behind a proxy, set the URL of the proxy in an environment variable called `HTTP_PROXY`.
+
 ## API
 
 You can find the full reference documentation of everything at: https://serverless-api.twilio-labs.com

--- a/packages/serverless-api/package.json
+++ b/packages/serverless-api/package.json
@@ -65,6 +65,7 @@
     "file-type": "^14.2.0",
     "form-data": "^2.5.0",
     "got": "^11.0.1",
+    "hpagent": "^0.1.1",
     "mime-types": "^2.1.22",
     "p-limit": "^2.3.0",
     "recursive-readdir": "^2.2.2",

--- a/packages/serverless-api/src/__tests__/client.test.ts
+++ b/packages/serverless-api/src/__tests__/client.test.ts
@@ -69,4 +69,14 @@ describe('createGotClient', () => {
       DEFAULT_TEST_CLIENT_CONFIG.authToken
     );
   });
+
+  test('works with HTTP_PROXY', async () => {
+    process.env.HTTP_PROXY = 'http://someproxy.com:8080';
+    const config = DEFAULT_TEST_CLIENT_CONFIG;
+    const client = createGotClient(config);
+    const agent = client.defaults.options.agent as any;
+    const httpAgent = agent.https as any;
+    expect(httpAgent.proxy.hostname).toBe('someproxy.com');
+    expect(httpAgent.proxy.port).toBe('8080');
+  });
 });

--- a/packages/serverless-api/src/client.ts
+++ b/packages/serverless-api/src/client.ts
@@ -61,6 +61,7 @@ import {
 } from 'got/dist/source';
 import pLimit, { Limit } from 'p-limit';
 import { deprecate } from 'util';
+import { HttpsProxyAgent } from 'hpagent';
 
 const log = debug('twilio-serverless-api:client');
 
@@ -75,7 +76,7 @@ export function createGotClient(config: ClientConfig): GotClient {
     username = config.username;
     password = config.password;
   }
-  const client = got.extend({
+  let client = got.extend({
     prefixUrl: getApiUrl(config),
     responseType: 'json',
     username: username,
@@ -84,6 +85,19 @@ export function createGotClient(config: ClientConfig): GotClient {
       'User-Agent': 'twilio-serverless-api',
     },
   }) as GotClient;
+  if (process.env.HTTP_PROXY) {
+    /*
+     * If environment variable HTTP_PROXY is set,
+     * add a proxy agent to the got client.
+     */
+    client = client.extend({
+      agent: {
+        https: new HttpsProxyAgent({
+          proxy: process.env.HTTP_PROXY,
+        }),
+      },
+    });
+  }
   return client;
 }
 


### PR DESCRIPTION
Fixes #227 

To be able to deploy functions behind an https proxy, we can now set the proxy URL in an env variable called `HTTP_PROXY`. This will set the appropriate http agent in the got client.

### Testing instructions
- Have a locally running forward proxy
- Be on a network behind a https authenticating proxy
- Set environment variable `HTTP_PROXY` to have the proxy's url

On `main`:
- Run `twilio-run deploy` inside a function directory
- Make sure the command hangs at `Configuring bare environment` and eventually fails

On this branch:
- Run `twilio-run deploy` inside a function directory
- Make sure the deployment succeeds

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
