### PR TITLE
feat(create-twilio-function): update default Node.js version

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -1,6 +1,6 @@
 module.exports = {
   twilioRun: '^2.6.0',
-  node: '10',
+  node: '12',
   typescript: '^3.8',
   serverlessRuntimeTypes: '^1.1',
   copyfiles: '^2.2.0',


### PR DESCRIPTION
Create-twilio-function should default to node12 instead of node10. Minor change to bump this.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X ] I acknowledge that all my contributions will be made under the project's license.
