### PR TITLE
fix(serverless-api): pagination was broken

### DIFF
--- a/packages/serverless-api/src/api/utils/pagination.ts
+++ b/packages/serverless-api/src/api/utils/pagination.ts
@@ -24,7 +24,7 @@ export async function getPaginatedResource<
   do {
     try {
       if (nextPageUrl.startsWith('http')) {
-        opts.prefixUrl = undefined;
+        opts.prefixUrl = '';
       }
       const resp = await client.request('get', nextPageUrl, opts);
       const body = resp.body as TList;


### PR DESCRIPTION
got changed its behaviour and setting prefixUrl to undefined no longer worked. Changing prefixUrl to empty string fixes this.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
