### PR TITLE
feat(templating): add support for .env.example files

### DIFF
--- a/packages/twilio-run/__tests__/templating/filesystem.test.ts
+++ b/packages/twilio-run/__tests__/templating/filesystem.test.ts
@@ -415,9 +415,9 @@ test('installation with an existing dot-env file', async () => {
   expect(writeFile).toHaveBeenCalledWith(
     join('testing', '.env'),
     '# Comment\n' +
-    'FOO=BAR\n' +
-    '\n\n' +
-    '# Variables for function ".env"\n' + // This seems to be a bug but is the output.
+      'FOO=BAR\n' +
+      '\n\n' +
+      '# Variables for function "example"\n' +
       '# ---\n' +
       'HELLO=WORLD\n',
     'utf8'

--- a/packages/twilio-run/src/templating/data.ts
+++ b/packages/twilio-run/src/templating/data.ts
@@ -149,6 +149,7 @@ export async function getTemplateFiles(
         return (
           file.name === 'package.json' ||
           file.name === '.env' ||
+          file.name === '.env.example' ||
           file.name === 'README.md'
         );
       })

--- a/packages/twilio-run/src/templating/filesystem.ts
+++ b/packages/twilio-run/src/templating/filesystem.ts
@@ -8,9 +8,9 @@ import { install, InstallResult } from 'pkg-install';
 import {
   downloadFile,
   fileExists,
+  mkdir,
   readFile,
   writeFile,
-  mkdir,
 } from '../utils/fs';
 import { logger } from '../utils/logger';
 import { TemplateFileInfo } from './data';
@@ -154,14 +154,14 @@ export async function writeFiles(
               path.join(assetsTargetDir, file.directory, file.name)
             ),
         };
-      } else if (file.type === '.env') {
+      } else if (file.type === '.env' || file.type === '.env.example') {
         return {
           title: 'Configuring Environment Variables in .env',
           task: async (ctx: any) => {
             const output = await writeEnvFile(
               file.content,
               targetDir,
-              file.name
+              namespace
             );
             ctx.env = output;
           },


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This adds support for `.env.example` files in templates as well as continuing to support `.env` for backwards compatibility.

There could be the situation that both exist in which case it would append the content of both. 

Additionally I fixed the fact that the added content didn't contain the namespace name.

fixes #112 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
