### PR TITLE
fix(serverless-api): use new /Status endpoint for builds

### DIFF
--- a/packages/serverless-api/src/__tests__/api/builds.test.ts
+++ b/packages/serverless-api/src/__tests__/api/builds.test.ts
@@ -1,0 +1,38 @@
+import { Response } from 'got/dist/source';
+import { EqualMatchingInjectorConfig, Mock, Times } from 'moq.ts';
+import { getBuildStatus } from '../../api/builds';
+import TwilioServerlessApiClient from '../../client';
+
+describe('getBuildStatus', () => {
+  test('makes a GET request to the /Status endpoint and extracts status', async () => {
+    const serviceSid = `ZS123`;
+    const buildSid = `ZB345`;
+    const requestMethod = 'get';
+    const path = `Services/${serviceSid}/Builds/${buildSid}/Status`;
+
+    const mockClient = new Mock<TwilioServerlessApiClient>({
+      injectorConfig: new EqualMatchingInjectorConfig(),
+    });
+    const mockResponse = new Mock<Response>();
+    mockResponse
+      .setup(instance => instance.body)
+      .returns({
+        status: 'completed',
+      });
+    mockClient
+      .setup(instance => instance.request(requestMethod, path))
+      .returns(Promise.resolve(mockResponse.object()));
+
+    const status = await getBuildStatus(
+      buildSid,
+      serviceSid,
+      mockClient.object()
+    );
+
+    expect(status).toEqual('completed');
+    mockClient.verify(
+      instance => instance.request(requestMethod, path),
+      Times.Once()
+    );
+  });
+});

--- a/packages/serverless-api/src/api/builds.ts
+++ b/packages/serverless-api/src/api/builds.ts
@@ -58,7 +58,7 @@ export async function getBuildStatus(
       'get',
       `Services/${serviceSid}/Builds/${buildSid}/Status`
     );
-    // const resp = await getBuild(buildSid, serviceSid, client);
+
     return ((resp.body as unknown) as BuildStatusResource).status;
   } catch (err) {
     log('%O', new ClientApiError(err));

--- a/packages/serverless-api/src/api/builds.ts
+++ b/packages/serverless-api/src/api/builds.ts
@@ -2,8 +2,14 @@
 
 import debug from 'debug';
 import querystring, { ParsedUrlQueryInput } from 'querystring';
-import { BuildConfig, BuildList, BuildResource, BuildStatus } from '../types';
 import { TwilioServerlessApiClient } from '../client';
+import {
+  BuildConfig,
+  BuildList,
+  BuildResource,
+  BuildStatus,
+  BuildStatusResource,
+} from '../types';
 import { DeployStatus } from '../types/consts';
 import { ClientApiError } from '../utils/error';
 import { sleep } from '../utils/sleep';
@@ -42,14 +48,18 @@ export async function getBuild(
  * @param {TwilioServerlessApiClient} client API client
  * @returns {Promise<BuildStatus>}
  */
-async function getBuildStatus(
+export async function getBuildStatus(
   buildSid: string,
   serviceSid: string,
   client: TwilioServerlessApiClient
 ): Promise<BuildStatus> {
   try {
-    const resp = await getBuild(buildSid, serviceSid, client);
-    return resp.status;
+    const resp = await client.request(
+      'get',
+      `Services/${serviceSid}/Builds/${buildSid}/Status`
+    );
+    // const resp = await getBuild(buildSid, serviceSid, client);
+    return ((resp.body as unknown) as BuildStatusResource).status;
   } catch (err) {
     log('%O', new ClientApiError(err));
     throw err;

--- a/packages/serverless-api/src/types/serverless-api.ts
+++ b/packages/serverless-api/src/types/serverless-api.ts
@@ -104,6 +104,14 @@ export interface BuildResource extends UpdateableResourceBase {
   runtime: string;
 }
 
+export interface BuildStatusResource {
+  sid: Sid;
+  service_sid: Sid;
+  account_sid: Sid;
+  url: string;
+  status: BuildStatus;
+}
+
 export interface BuildList extends BaseList<'builds'> {
   builds: BuildResource[];
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

There is a "new" dedicated `/Status` endpoint for Builds that is designed to be long polled. 

fix #193 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
