### PR TITLE
chore(runtime-handler): move runtime-handler into monorepo

### DIFF
--- a/packages/runtime-handler/CHANGELOG.md
+++ b/packages/runtime-handler/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+<a name="1.0.1"></a>
+## 1.0.1 (2021-04-16)
+
+
+

--- a/packages/runtime-handler/README.md
+++ b/packages/runtime-handler/README.md
@@ -1,0 +1,7 @@
+# `@twilio/runtime-handler`
+
+This package defines the Twilio Functions Runtime version.
+
+## License
+
+MIT

--- a/packages/runtime-handler/__tests__/runtime-handler.test.ts
+++ b/packages/runtime-handler/__tests__/runtime-handler.test.ts
@@ -1,0 +1,9 @@
+'use strict';
+
+const runtimeHandler = require('..');
+
+describe('@twilio/runtime-handler', () => {
+  test('exports nothing', () => {
+    expect(runtimeHandler).toEqual({});
+  });
+});

--- a/packages/runtime-handler/jest.config.js
+++ b/packages/runtime-handler/jest.config.js
@@ -1,0 +1,12 @@
+const base = require('../../jest.config.base.js');
+
+module.exports = {
+  ...base,
+  globals: {
+    'ts-jest': {
+      tsConfig: './tsconfig.test.json',
+    },
+  },
+  name: 'serverless-api',
+  displayName: 'serverless-api',
+};

--- a/packages/runtime-handler/package.json
+++ b/packages/runtime-handler/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@twilio/runtime-handler",
+  "version": "1.0.1",
+  "description": "Stub runtime for Twilio Functions",
+  "keywords": [
+    "twilio",
+    "twilio-functions"
+  ],
+  "author": "Twilio Inc. <open-source@twilio.com> (https://www.twilio.com/labs)",
+  "homepage": "https://github.com/twilio-labs/serverless-toolkit/tree/main/packages/runtime-handler#readme",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "src": "src",
+    "test": "__tests__",
+    "dist": "dist"
+  },
+  "files": [
+    "dist",
+    "!dist/**/__tests__/*"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/twilio-labs/serverless-toolkit.git"
+  },
+  "scripts": {
+    "jest": "jest",
+    "test": "run-s build:noemit jest",
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "build:noemit": "tsc --noEmit",
+    "docs": "typedoc --options typedoc.json",
+    "clean": "rimraf ./dist",
+    "prepack": "run-s clean build"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.16",
+    "jest": "^24.8.0",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^2.6.3",
+    "ts-jest": "^24.0.2",
+    "typescript": "^3.8.3"
+  },
+  "bugs": {
+    "url": "https://github.com/twilio-labs/serverless-toolkit/issues"
+  }
+}

--- a/packages/runtime-handler/src/index.ts
+++ b/packages/runtime-handler/src/index.ts
@@ -1,0 +1,1 @@
+// placeholder

--- a/packages/runtime-handler/tsconfig.json
+++ b/packages/runtime-handler/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "./dist" /* Redirect output structure to the directory. */
+  },
+  "exclude": ["node_modules", "**/*.test.ts", "dist", "**/__mocks__/*.ts"]
+}

--- a/packages/runtime-handler/tsconfig.test.json
+++ b/packages/runtime-handler/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "incremental": true
+  }
+}


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Right now the `@twilio/runtime-handler` package wasn't version controlled. It's currently empty but with the next version we'll start extracting the local dev logic from `twilio-run` into this package so tracking them together even though it's a different "scope" makes sense to me.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
