### PR TITLE
fix(serverless-api): add request url to API error logs

### DIFF
--- a/packages/serverless-api/src/utils/__tests__/error.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/error.test.ts
@@ -1,16 +1,23 @@
 import nock from 'nock';
 import util from 'util';
+import { AccountSidConfig, UsernameConfig } from '../../../dist';
 import { createGotClient } from '../../client';
+import {
+  DEFAULT_TEST_CLIENT_CONFIG,
+  DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD,
+} from '../../__fixtures__/base-fixtures';
 import { ClientApiError } from '../error';
-import { DEFAULT_TEST_CLIENT_CONFIG } from '../../__fixtures__/base-fixtures';
 
 describe('ClientApiError', () => {
   let apiNock = nock('https://serverless.twilio.com');
-  let config = DEFAULT_TEST_CLIENT_CONFIG;
+  let config:
+    | UsernameConfig
+    | AccountSidConfig = DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD;
   let apiClient = createGotClient(config);
 
   beforeEach(() => {
     apiNock = nock('https://serverless.twilio.com');
+    config = DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD;
     apiClient = createGotClient(config);
   });
 
@@ -40,12 +47,73 @@ describe('ClientApiError', () => {
       status: 400,
     });
 
+    config = DEFAULT_TEST_CLIENT_CONFIG;
+    apiClient = createGotClient(config);
+
     try {
       const resp = await apiClient.get('Services');
     } catch (err) {
       const newError = new ClientApiError(err);
       const stringVersion = util.inspect(newError);
-      expect(stringVersion).not.toContain(config.authToken);
+      expect(stringVersion.includes(config.authToken)).toBe(false);
+    }
+  });
+
+  test('does not contain any password', async () => {
+    const scope = apiNock.get('/v1/Services').reply(400, {
+      code: 20001,
+      message: 'Services are limited to less than or equal to 9000',
+      more_info: 'https://www.twilio.com/docs/errors/20001',
+      status: 400,
+    });
+
+    try {
+      const resp = await apiClient.get('Services');
+    } catch (err) {
+      const newError = new ClientApiError(err);
+      const stringVersion = util.inspect(newError);
+      expect(stringVersion.includes((config as UsernameConfig).password)).toBe(
+        false
+      );
+    }
+  });
+
+  test('contains URL and status code for basic HTTP Errors', async () => {
+    const scope = apiNock.get('/v1/Services/ZS1111').reply(404, {});
+
+    try {
+      const resp = await apiClient.get('Services/ZS1111');
+    } catch (err) {
+      const newError = new ClientApiError(err);
+      const expectedUrl = 'https://serverless.twilio.com/v1/Services/ZS1111';
+      expect(newError.code).toEqual(404);
+      expect(newError.url).toEqual(expectedUrl);
+
+      const stringVersion = util.inspect(newError);
+      expect(stringVersion.includes(expectedUrl)).toBe(true);
+      expect(stringVersion.includes('404')).toBe(true);
+    }
+  });
+
+  test('contains URL and API code for Twilio API Errrors', async () => {
+    const scope = apiNock.get('/v1/Services/ZS1111').reply(400, {
+      code: 20001,
+      message: 'Services are limited to less than or equal to 9000',
+      more_info: 'https://www.twilio.com/docs/errors/20001',
+      status: 400,
+    });
+
+    try {
+      const resp = await apiClient.get('Services/ZS1111');
+    } catch (err) {
+      const newError = new ClientApiError(err);
+      const expectedUrl = 'https://serverless.twilio.com/v1/Services/ZS1111';
+      expect(newError.code).toEqual(20001);
+      expect(newError.url).toEqual(expectedUrl);
+
+      const stringVersion = util.inspect(newError);
+      expect(stringVersion.includes(expectedUrl)).toBe(true);
+      expect(stringVersion.includes('20001')).toBe(true);
     }
   });
 });


### PR DESCRIPTION
We wrap error events from the API/Got into a dedicated class. The URL helps support to debug issues
but wasn't in the debug logs since this change. This commit adds the URL back

fix #167

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
