### PR TITLE
feat: check for legacy config

### DIFF
--- a/packages/twilio-run/src/checks/legacy-config.ts
+++ b/packages/twilio-run/src/checks/legacy-config.ts
@@ -1,4 +1,5 @@
 import { stripIndent } from 'common-tags';
+import inquirer from 'inquirer';
 import path from 'path';
 import { fileExistsSync } from '../utils/fs';
 import { logger } from '../utils/logger';
@@ -14,17 +15,37 @@ export function printConfigWarning() {
   logger.warn(msg, title);
 }
 
+export async function promptForContinue(): Promise<boolean> {
+  const answers = await inquirer.prompt([
+    {
+      name: 'continue',
+      type: 'confirm',
+      default: true,
+      message: 'Do you want to continue with the ignored configuration?',
+    },
+  ]);
+  return answers.continue;
+}
+
 /**
- * This function checks if there is a .twilio-functions file in the project and prints a warning.
+ * This function checks if there is a .twilio-functions file in the project and prints a warning and an optional continue prompt.
  *
  * **Only checks** in the current working directory because it's being executed at the beginning of the script.
  *
  * @export
  */
-export function checkLegacyConfig() {
-  const legacyFilePath = path.resolve(process.cwd(), '.twilio-functions');
+export async function checkLegacyConfig(
+  cwd: string = process.cwd(),
+  shouldPrompt: boolean = true
+) {
+  const legacyFilePath = path.resolve(cwd, '.twilio-functions');
   if (fileExistsSync(legacyFilePath)) {
     printConfigWarning();
+    if (shouldPrompt) {
+      return promptForContinue();
+    } else {
+      return true;
+    }
   }
 }
 

--- a/packages/twilio-run/src/commands/deploy.ts
+++ b/packages/twilio-run/src/commands/deploy.ts
@@ -4,6 +4,7 @@ import { Ora } from 'ora';
 import path from 'path';
 import { Argv } from 'yargs';
 import { checkConfigForCredentials } from '../checks/check-credentials';
+import checkLegacyConfig from '../checks/legacy-config';
 import checkProjectStructure from '../checks/project-structure';
 import {
   DeployCliFlags,
@@ -80,6 +81,11 @@ export async function handler(
 
   const cwd = flags.cwd ? path.resolve(flags.cwd) : process.cwd();
   flags.cwd = cwd;
+  const continueWork = await checkLegacyConfig(cwd);
+  if (!continueWork) {
+    process.exit(1);
+  }
+
   const command = getFullCommand(flags);
   await checkProjectStructure(cwd, command, true);
 

--- a/packages/twilio-run/src/commands/list.ts
+++ b/packages/twilio-run/src/commands/list.ts
@@ -43,10 +43,7 @@ export async function handler(
 ): Promise<void> {
   setLogLevelByName(flags.logLevel);
 
-  const continueWork = await checkLegacyConfig(flags.cwd);
-  if (!continueWork) {
-    process.exit(1);
-  }
+  await checkLegacyConfig(flags.cwd, false);
 
   let config: ListConfig;
   try {

--- a/packages/twilio-run/src/commands/list.ts
+++ b/packages/twilio-run/src/commands/list.ts
@@ -2,6 +2,7 @@ import { TwilioServerlessApiClient } from '@twilio-labs/serverless-api';
 import { Argv } from 'yargs';
 import { checkConfigForCredentials } from '../checks/check-credentials';
 import checkForValidServiceSid from '../checks/check-service-sid';
+import checkLegacyConfig from '../checks/legacy-config';
 import { getConfigFromFlags, ListCliFlags, ListConfig } from '../config/list';
 import {
   ALL_FLAGS,
@@ -41,6 +42,11 @@ export async function handler(
   externalCliOptions?: ExternalCliOptions
 ): Promise<void> {
   setLogLevelByName(flags.logLevel);
+
+  const continueWork = await checkLegacyConfig(flags.cwd);
+  if (!continueWork) {
+    process.exit(1);
+  }
 
   let config: ListConfig;
   try {

--- a/packages/twilio-run/src/commands/logs.ts
+++ b/packages/twilio-run/src/commands/logs.ts
@@ -5,6 +5,7 @@ import {
 import { Argv } from 'yargs';
 import { checkConfigForCredentials } from '../checks/check-credentials';
 import checkForValidServiceSid from '../checks/check-service-sid';
+import checkLegacyConfig from '../checks/legacy-config';
 import { getConfigFromFlags, LogsCliFlags, LogsConfig } from '../config/logs';
 import {
   ALL_FLAGS,
@@ -44,6 +45,11 @@ export async function handler(
   externalCliOptions?: ExternalCliOptions
 ): Promise<void> {
   setLogLevelByName(flags.logLevel);
+
+  const continueWork = await checkLegacyConfig(flags.cwd);
+  if (!continueWork) {
+    process.exit(1);
+  }
 
   let config: LogsConfig;
   try {

--- a/packages/twilio-run/src/commands/logs.ts
+++ b/packages/twilio-run/src/commands/logs.ts
@@ -46,10 +46,7 @@ export async function handler(
 ): Promise<void> {
   setLogLevelByName(flags.logLevel);
 
-  const continueWork = await checkLegacyConfig(flags.cwd);
-  if (!continueWork) {
-    process.exit(1);
-  }
+  await checkLegacyConfig(flags.cwd, false);
 
   let config: LogsConfig;
   try {

--- a/packages/twilio-run/src/commands/promote.ts
+++ b/packages/twilio-run/src/commands/promote.ts
@@ -3,6 +3,7 @@ import { ClientApiError } from '@twilio-labs/serverless-api/dist/utils/error';
 import { Ora } from 'ora';
 import { Argv } from 'yargs';
 import { checkConfigForCredentials } from '../checks/check-credentials';
+import checkLegacyConfig from '../checks/legacy-config';
 import {
   getConfigFromFlags,
   PromoteCliFlags,
@@ -53,6 +54,12 @@ export async function handler(
   externalCliOptions?: ExternalCliOptions
 ): Promise<void> {
   setLogLevelByName(flags.logLevel);
+
+  const continueWork = await checkLegacyConfig(flags.cwd);
+  if (!continueWork) {
+    process.exit(1);
+  }
+
   let config: PromoteConfig;
   try {
     config = await getConfigFromFlags(flags, externalCliOptions);

--- a/packages/twilio-run/src/commands/start.ts
+++ b/packages/twilio-run/src/commands/start.ts
@@ -1,6 +1,7 @@
 import { Server } from 'http';
 import inquirer from 'inquirer';
 import { Argv } from 'yargs';
+import checkLegacyConfig from '../checks/legacy-config';
 import checkNodejsVersion from '../checks/nodejs-version';
 import checkProjectStructure from '../checks/project-structure';
 import { getConfigFromCli, getUrl, StartCliFlags } from '../config/start';
@@ -48,6 +49,7 @@ export async function handler(
   setLogLevelByName(argv.logLevel);
 
   checkNodejsVersion();
+  await checkLegacyConfig(argv.cwd, false);
 
   const config = await getConfigFromCli(argv, cliInfo, externalCliOptions);
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

For all "destructive" commands I also added a prompt that allows you to stop execution. Since "start" isn't destructive it only puts a warning out.

![Screen_Shot_2021-04-20_at_15_31_44](https://user-images.githubusercontent.com/1505101/115472150-203ba400-a1ee-11eb-81fc-73ad08ce8ea3.png)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
