### PR TITLE
feat(twilio-run:logs): adds production flag

### DIFF
--- a/packages/twilio-run/__tests__/config/logs.test.ts
+++ b/packages/twilio-run/__tests__/config/logs.test.ts
@@ -1,0 +1,40 @@
+import { getConfigFromFlags, LogsCliFlags } from '../../src/config/logs';
+
+const baseFlags = {
+  $0: 'twilio-run',
+  _: ['logs'],
+  serviceSid: 'ZS11112222111122221111222211112222',
+} as LogsCliFlags;
+
+describe('getConfigFromFlags', () => {
+  test('should return a config', async () => {
+    const flags = { ...baseFlags };
+    const config = await getConfigFromFlags(flags);
+    expect(config).toBeDefined();
+    expect(config.serviceSid).toBe(baseFlags.serviceSid);
+  });
+
+  test('should set environment to "dev" by default', async () => {
+    const flags = { ...baseFlags };
+    const config = await getConfigFromFlags(flags);
+    expect(config.environment).toBe('dev');
+  });
+
+  test('should set environment with a flag', async () => {
+    const flags = { ...baseFlags, environment: 'stage' };
+    const config = await getConfigFromFlags(flags);
+    expect(config.environment).toBe('stage');
+  });
+
+  test('should set environment to empty string with "production" flag', async () => {
+    const flags = { ...baseFlags, production: true };
+    const config = await getConfigFromFlags(flags);
+    expect(config.environment).toBe('');
+  });
+
+  test('production overrides setting environment directly', async () => {
+    const flags = { ...baseFlags, production: true, environment: 'stage' };
+    const config = await getConfigFromFlags(flags);
+    expect(config.environment).toBe('');
+  });
+});

--- a/packages/twilio-run/src/commands/logs.ts
+++ b/packages/twilio-run/src/commands/logs.ts
@@ -94,11 +94,17 @@ export const cliInfo: CliInfo = {
       'tail',
       'output-format',
       'log-cache-size',
+      'production',
     ]),
     environment: {
       ...ALL_FLAGS['environment'],
       describe: 'The environment to retrieve the logs for',
       default: 'dev',
+    },
+    production: {
+      ...ALL_FLAGS['production'],
+      describe:
+        'Retrieve logs for the production environment. Overrides the "environment" flag',
     },
   },
 };
@@ -110,8 +116,8 @@ function optionBuilder(yargs: Argv<any>): Argv<LogsCliFlags> {
       'Prints the last 50 logs for the current project in the dev environment'
     )
     .example(
-      '$0 logs --environment=production',
-      'Prints the last 50 logs for the current project in the production environment'
+      '$0 logs --environment=stage',
+      'Prints the last 50 logs for the current project in the stage environment'
     )
     .example(
       '$0 logs --tail',

--- a/packages/twilio-run/src/config/logs.ts
+++ b/packages/twilio-run/src/config/logs.ts
@@ -35,6 +35,7 @@ export type ConfigurableLogsCliFlags = Pick<
   | 'tail'
   | 'outputFormat'
   | 'logCacheSize'
+  | 'production'
 >;
 export type LogsCliFlags = Arguments<ConfigurableLogsCliFlags>;
 
@@ -59,6 +60,10 @@ export async function getConfigFromFlags(
   flags = mergeFlagsAndConfig<LogsCliFlags>(configFlags, flags, cliInfo);
   cwd = flags.cwd || cwd;
   environment = flags.environment || environment;
+
+  if (flags.production) {
+    environment = '';
+  }
 
   const { localEnv: envFileVars, envPath } = await readLocalEnvFile(flags);
   const { username, password } = await getCredentialsFromFlags(


### PR DESCRIPTION
Fixes #208.

Other commands make a `--production` flag available that sets the environment to the empty string. The `logs` command was missing this convenience, and this PR adds it in.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
