### PR TITLE
fix(twilio-run:start): load functions & assets in forked process

### DIFF
--- a/packages/twilio-run/src/runtime/internal/functionRunner.ts
+++ b/packages/twilio-run/src/runtime/internal/functionRunner.ts
@@ -3,6 +3,7 @@ import { Response } from './response';
 import { serializeError } from 'serialize-error';
 import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
 import { constructGlobalScope, constructContext } from '../route';
+import { getRouteMap } from '../internal/route-cache';
 
 const sendDebugMessage = (debugMessage: string, ...debugArgs: any) => {
   process.send && process.send({ debugMessage, debugArgs });
@@ -48,9 +49,10 @@ const handleSuccess = (responseObject?: string | number | boolean | object) => {
   }
 };
 
-process.on('message', ({ functionPath, event, config, path }) => {
+process.on('message', async ({ functionPath, event, config, path }) => {
   const { handler } = require(functionPath);
   try {
+    await getRouteMap(config);
     constructGlobalScope(config);
     const context = constructContext(config, path);
     sendDebugMessage('Context for %s: %p', path, context);

--- a/packages/twilio-run/src/runtime/internal/route-cache.ts
+++ b/packages/twilio-run/src/runtime/internal/route-cache.ts
@@ -1,6 +1,8 @@
 import { ServerlessResourceConfigWithFilePath } from '@twilio-labs/serverless-api';
+import { SearchConfig } from '@twilio-labs/serverless-api/dist/utils';
 import { Merge } from 'type-fest';
-import { RouteInfo } from './runtime-paths';
+import { RouteInfo, getFunctionsAndAssets } from './runtime-paths';
+import { StartCliConfig } from '../../config/start';
 
 type ExtendedRouteInfo =
   | Merge<{ type: 'function' }, ServerlessResourceConfigWithFilePath>
@@ -10,7 +12,22 @@ const allRoutes = new Map<string, ExtendedRouteInfo>();
 const assetsCache = new Set<ServerlessResourceConfigWithFilePath>();
 const functionsCache = new Set<ServerlessResourceConfigWithFilePath>();
 
-export function setRoutes({ functions, assets }: RouteInfo) {
+export async function getRouteMap(config: StartCliConfig) {
+  const searchConfig: SearchConfig = {};
+
+  if (config.functionsFolderName) {
+    searchConfig.functionsFolderNames = [config.functionsFolderName];
+  }
+
+  if (config.assetsFolderName) {
+    searchConfig.assetsFolderNames = [config.assetsFolderName];
+  }
+
+  let routes = await getFunctionsAndAssets(config.baseDir, searchConfig);
+  return setRoutes(routes);
+}
+
+function setRoutes({ functions, assets }: RouteInfo) {
   allRoutes.clear();
   assetsCache.clear();
   functionsCache.clear();


### PR DESCRIPTION
Due to changes around forking processes to run functions, the functions and assets cache wasn't being populated in the forked process. This slightly refactors how routes are cached by moving repeated calls into a `getRouteMap` function within route-cache and then using that in both the server, to populate the cache for the terminal display, and inside the forked process so that it populates the cache before building the global scope.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
