### PR TITLE
fix(twilio-run): continue commands with no legacy config

### DIFF
--- a/packages/twilio-run/__tests__/checks/legacy-config.test.ts
+++ b/packages/twilio-run/__tests__/checks/legacy-config.test.ts
@@ -45,19 +45,22 @@ describe('printLegacyConfig', () => {
 describe('checkLegacyConfig', () => {
   it('should print a warning if the config file exists', async () => {
     SHOULD_FILE_EXIST = true;
-    await checkLegacyConfig();
+    const result = await checkLegacyConfig();
+    expect(result).toBe(true);
     expect(logger.warn).toHaveBeenCalled();
   });
 
   it('should not print a warning if the file does not exist', async () => {
     SHOULD_FILE_EXIST = false;
-    await checkLegacyConfig();
+    const result = await checkLegacyConfig();
+    expect(result).toBe(true);
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('should use default path to look for file', async () => {
     SHOULD_FILE_EXIST = true;
-    await checkLegacyConfig();
+    const result = await checkLegacyConfig();
+    expect(result).toBe(true);
     expect(mocked(fileExistsSync)).toHaveBeenCalledWith(
       path.resolve(process.cwd(), '.twilio-functions')
     );
@@ -65,7 +68,8 @@ describe('checkLegacyConfig', () => {
 
   it('should override directory to look for file', async () => {
     SHOULD_FILE_EXIST = true;
-    await checkLegacyConfig('/tmp');
+    const result = await checkLegacyConfig('/tmp');
+    expect(result).toBe(true);
     expect(mocked(fileExistsSync)).toHaveBeenCalledWith(
       path.resolve('/tmp', '.twilio-functions')
     );

--- a/packages/twilio-run/src/checks/legacy-config.ts
+++ b/packages/twilio-run/src/checks/legacy-config.ts
@@ -46,6 +46,8 @@ export async function checkLegacyConfig(
     } else {
       return true;
     }
+  } else {
+    return true;
   }
 }
 


### PR DESCRIPTION
In the case of a new project that doesn't have a `.twilio-functions` file, or any new config either, the `checkLegacyConfig` function would return `undefined`. This resulted in commands, like deploy, exiting. This adds a `return true` for when there is no legacy config file.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
