### PR TITLE
fix(serverless-api): fixes assets paths in deployment

### DIFF
--- a/packages/plugin-assets/src/upload.js
+++ b/packages/plugin-assets/src/upload.js
@@ -93,7 +93,7 @@ ${debugFlagMessage}`,
       filePath = resolve(file);
       debug(`Reading file from ${filePath}`);
       const assetContent = await readFile(filePath);
-      const path = `${basename(filePath)}`;
+      const path = `${encodeURIComponent(basename(filePath))}`;
       const newAsset = {
         name: path,
         access: 'public',

--- a/packages/serverless-api/src/api/assets.ts
+++ b/packages/serverless-api/src/api/assets.ts
@@ -142,7 +142,7 @@ export async function createAssetVersion(
     };
 
     const form = new FormData();
-    form.append('Path', encodeURIComponent(asset.path));
+    form.append('Path', asset.path);
     form.append('Visibility', asset.access);
     form.append('Content', asset.content, contentOpts);
 


### PR DESCRIPTION
So, as part of the assets plugin, I decided that encoding the path of an asset was a good thing and I decided to do so at the point it is sent to the API in the serverless-api project. However, I forgot that that would affect assets getting deployed from twilio-run. Asset paths were getting their initial forward slash encoded and that broke their expected URLs/paths.

I have reverted the change in serverless API and just URI encode the path from inside the assets plugin now.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
