### PR TITLE
fix(create-twilio-function): use latest twilio-run version

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -1,6 +1,8 @@
+const pkgJson = require('../../package.json');
+
 module.exports = {
   twilio: '^3.56',
-  twilioRun: '^2.6.0',
+  twilioRun: pkgJson.dependencies['twilio-run'],
   node: '12',
   typescript: '^3.8',
   serverlessRuntimeTypes: '^1.1',


### PR DESCRIPTION
Previously we were using a hardcoded version of twilio-run. Since everything is now in the same
monorepo we should use the latest dependency that create-twilio-function has.

fix #259

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
