### PR TITLE
fix(twilio-run): remove api flags from start command

### DIFF
--- a/packages/twilio-run/src/commands/start.ts
+++ b/packages/twilio-run/src/commands/start.ts
@@ -5,12 +5,7 @@ import checkLegacyConfig from '../checks/legacy-config';
 import checkNodejsVersion from '../checks/nodejs-version';
 import checkProjectStructure from '../checks/project-structure';
 import { getConfigFromCli, getUrl, StartCliFlags } from '../config/start';
-import {
-  ALL_FLAGS,
-  BASE_API_FLAG_NAMES,
-  BASE_CLI_FLAG_NAMES,
-  getRelevantFlags,
-} from '../flags';
+import { ALL_FLAGS, BASE_CLI_FLAG_NAMES, getRelevantFlags } from '../flags';
 import { printRouteInfo } from '../printers/start';
 import { createServer } from '../runtime/server';
 import { startInspector } from '../runtime/utils/inspector';
@@ -138,7 +133,6 @@ export async function handler(
 export const cliInfo: CliInfo = {
   options: {
     ...getRelevantFlags([
-      ...BASE_API_FLAG_NAMES,
       ...BASE_CLI_FLAG_NAMES,
       'load-local-env',
       'port',


### PR DESCRIPTION
The start command was showing among others --username --password and others that should not be
included in this.

fix #260

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
