### PR TITLE
fix(twilio-run): show service sid if available instead of name

### DIFF
--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -6,8 +6,8 @@ import { DeployStatus } from './consts';
 import {
   AssetResource,
   EnvironmentVariables,
-  ServerlessResourceConfig,
   FunctionResource,
+  ServerlessResourceConfig,
 } from './generic';
 import { Sid } from './serverless-api';
 
@@ -111,6 +111,7 @@ export type DeployResult = {
   functionResources: FunctionResource[];
   assetResources: AssetResource[];
   runtime: string;
+  serviceName: string;
 };
 
 export type StatusUpdate = {

--- a/packages/twilio-run/src/commands/deploy.ts
+++ b/packages/twilio-run/src/commands/deploy.ts
@@ -55,9 +55,9 @@ function handleError(
           '-n',
           'my-new-service-name',
         ])}
-      - Deploy to the existing service with the name "${(err as any)[
-        'serviceName'
-      ] || config.serviceName}"
+      - Deploy to the existing service with the name "${
+        (err as any)['serviceName'] || config.serviceName
+      }"
         > ${constructCommandName(fullCommand, 'deploy', [
           '--override-existing-project',
         ])}
@@ -114,7 +114,7 @@ export async function handler(
   const spinner = getOraSpinner('Deploying Function').start();
   try {
     const client = new TwilioServerlessApiClient(config);
-    client.on('status-update', evt => {
+    client.on('status-update', (evt) => {
       spinner.text = evt.message + '\n';
     });
     const result = await client.deployLocalProject(config);

--- a/packages/twilio-run/src/config/deploy.ts
+++ b/packages/twilio-run/src/config/deploy.ts
@@ -102,7 +102,9 @@ export async function getConfigFromFlags(
 
   let serviceName: string | undefined = await getServiceNameFromFlags(flags);
 
-  if (!serviceName) {
+  if (serviceSid?.startsWith('ZS')) {
+    serviceName = '';
+  } else if (!serviceName) {
     throw new Error(
       'Please pass --service-name or add a "name" field to your package.json'
     );

--- a/packages/twilio-run/src/printers/deploy.ts
+++ b/packages/twilio-run/src/printers/deploy.ts
@@ -32,7 +32,7 @@ function plainPrintDeployedResources(
   result: DeployResult
 ) {
   const functionsOutput: string = columnify(
-    result.functionResources.sort(sortByAccess).map(fn => ({
+    result.functionResources.sort(sortByAccess).map((fn) => ({
       ...fn,
       url: `https://${result.domain}${fn.path}`,
     })),
@@ -43,7 +43,7 @@ function plainPrintDeployedResources(
   );
 
   const assetsOutput: string = columnify(
-    result.assetResources.sort(sortByAccess).map(asset => ({
+    result.assetResources.sort(sortByAccess).map((asset) => ({
       ...asset,
       url: `https://${result.domain}${asset.path}`,
     })),
@@ -83,12 +83,16 @@ function prettyPrintConfigInfo(config: DeployLocalProjectConfig) {
     dependencyString = Object.keys(config.pkgJson.dependencies).join(', ');
   }
 
+  const serviceInfo = config.serviceSid?.startsWith('ZS')
+    ? chalk`{bold.cyan Service SID}\t${config.serviceSid}`
+    : chalk`{bold.cyan Service Name}\t${config.serviceName}`;
+
   logger.info('\nDeploying functions & assets to the Twilio Runtime');
   writeOutput(
     chalk`
 {bold.cyan Username}\t${config.username}
 {bold.cyan Password}\t${redactPartOfString(config.password)}
-{bold.cyan Service Name}\t${config.serviceName}
+${serviceInfo}
 {bold.cyan Environment}\t${config.functionsEnv}
 {bold.cyan Root Directory}\t${config.cwd}
 {bold.cyan Dependencies}\t${dependencyString}
@@ -106,12 +110,18 @@ function plainPrintConfigInfo(config: DeployLocalProjectConfig) {
   const printObj = {
     account: config.username,
     serviceName: config.serviceName,
+    serviceSid: config.serviceSid,
     environment: config.functionsEnv,
     rootDirectory: config.cwd,
     dependencies: dependencyString,
     environmentVariables: Object.keys(config.env).join(','),
     runtime: config.runtime,
   };
+
+  if (printObj.serviceSid) {
+    delete printObj.serviceName;
+  }
+
   writeOutput(`configInfo\n${printObjectWithoutHeaders(printObj)}\n`);
 }
 
@@ -132,7 +142,7 @@ function prettyPrintDeployedResources(
 {bold.cyan.underline Deployment Details}
 {bold.cyan Domain:} ${result.domain}
 {bold.cyan Service:}
-   ${config.serviceName} {dim (${result.serviceSid})}
+   ${result.serviceName} {dim (${result.serviceSid})}
 {bold.cyan Environment:}
    ${config.functionsEnv} {dim (${result.environmentSid})}
 {bold.cyan Build SID:}
@@ -147,7 +157,7 @@ function prettyPrintDeployedResources(
   if (result.functionResources) {
     const functionMessage = result.functionResources
       .sort(sortByAccess)
-      .map(fn => {
+      .map((fn) => {
         const accessPrefix =
           fn.access !== 'public' ? chalk`{bold [${fn.access}]} ` : '';
         return chalk`   ${accessPrefix}{dim https://${result.domain}}${fn.path}`;
@@ -160,7 +170,7 @@ function prettyPrintDeployedResources(
   if (result.assetResources) {
     const assetMessage = result.assetResources
       .sort(sortByAccess)
-      .map(asset => {
+      .map((asset) => {
         const accessPrefix =
           asset.access !== 'public' ? chalk`{bold [${asset.access}]} ` : '';
         const accessUrl =

--- a/packages/twilio-run/src/serverless-api/utils.ts
+++ b/packages/twilio-run/src/serverless-api/utils.ts
@@ -41,7 +41,7 @@ export async function getFunctionServiceSid(
       deployInfoCache[username].serviceSid
     ) {
       debug(
-        'Found service sid from debug info, "%s"',
+        'Found service sid from deploy info, "%s"',
         deployInfoCache[username].serviceSid
       );
       return deployInfoCache[username].serviceSid;


### PR DESCRIPTION
If a Service SID is defined in your config or .twiliodeployinfo we should pick that to display
instead of the name as the name might not be the actual name of the service. Similarly in the deploy
result we'll actually show the real service name not the presumed one.

BREAKING CHANGE: The output of the config info in deployment changed

fix #262

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
