### PR TITLE
feat(create-twilio-function): generate default config file

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function.js
+++ b/packages/create-twilio-function/src/create-twilio-function.js
@@ -19,6 +19,7 @@ const {
   createNvmrcFile,
   createTsconfigFile,
   createEmptyFileStructure,
+  createServerlessConfigFile,
 } = require('./create-twilio-function/create-files');
 const createGitignore = require('./create-twilio-function/create-gitignore');
 const importCredentials = require('./create-twilio-function/import-credentials');
@@ -113,6 +114,7 @@ async function createTwilioFunction(config) {
   });
   await createNvmrcFile(projectDir);
   await createPackageJSON(projectDir, config.name, projectType);
+  await createServerlessConfigFile(projectDir);
   if (projectType === 'typescript') {
     await createTsconfigFile(projectDir);
   }

--- a/packages/create-twilio-function/src/create-twilio-function/create-files.js
+++ b/packages/create-twilio-function/src/create-twilio-function/create-files.js
@@ -1,5 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const {
+  writeDefaultConfigFile,
+} = require('twilio-run/dist/templating/defaultConfig');
 const { promisify } = require('util');
 
 const versions = require('./versions');
@@ -69,10 +72,10 @@ function createPackageJSON(pathName, name, projectType = 'javascript') {
 }
 
 function copyRecursively(src, dest) {
-  return readdir(src).then(children => {
+  return readdir(src).then((children) => {
     return Promise.all(
-      children.map(child =>
-        stat(path.join(src, child)).then(stats => {
+      children.map((child) =>
+        stat(path.join(src, child)).then((stats) => {
           if (stats.isDirectory()) {
             return mkdir(path.join(dest, child)).then(() =>
               copyRecursively(path.join(src, child), path.join(dest, child))
@@ -107,6 +110,10 @@ function createNvmrcFile(pathName) {
   const fullPath = path.join(pathName, '.nvmrc');
   const content = versions.node;
   return createFile(fullPath, content);
+}
+
+function createServerlessConfigFile(pathName) {
+  return writeDefaultConfigFile(pathName, false, '.twilioserverlessrc');
 }
 
 function createTsconfigFile(pathName) {
@@ -148,6 +155,7 @@ module.exports = {
   createExampleFromTemplates,
   createEnvFile,
   createNvmrcFile,
+  createServerlessConfigFile,
   createTsconfigFile,
   createEmptyFileStructure,
 };

--- a/packages/create-twilio-function/tests/create-files.test.js
+++ b/packages/create-twilio-function/tests/create-files.test.js
@@ -18,6 +18,7 @@ const {
   createNvmrcFile,
   createTsconfigFile,
   createEmptyFileStructure,
+  createServerlessConfigFile,
 } = require('../src/create-twilio-function/create-files');
 
 function setupDir() {
@@ -296,6 +297,49 @@ describe('create-files', () => {
       } catch (e) {
         expect(e.toString()).toMatch('file already exists');
       }
+      cleanUp();
+    });
+  });
+
+  describe('createServerlessConfigFile', () => {
+    test('it creates a new .twilioserverlessrc file', async () => {
+      const { tmpDir: scratchDir, cleanUp } = setupDir();
+      const name = 'test-serverlessrc-1';
+      const basePath = path.join(scratchDir, name);
+      fs.mkdirSync(basePath, { recursive: true });
+
+      await createServerlessConfigFile(basePath);
+      const file = await stat(path.join(basePath, '.twilioserverlessrc'));
+      expect(file.isFile());
+      const contents = fs.readFileSync(
+        path.join(basePath, '.twilioserverlessrc'),
+        {
+          encoding: 'utf-8',
+        }
+      );
+      expect(contents.startsWith('{')).toBe(true);
+      cleanUp();
+    });
+
+    test('it does not override if there is already a file', async () => {
+      const { tmpDir: scratchDir, cleanUp } = setupDir();
+      const name = 'test-serverlessrc-2';
+      const basePath = path.join(scratchDir, name);
+      fs.mkdirSync(basePath, { recursive: true });
+
+      fs.closeSync(
+        fs.openSync(path.join(basePath, '.twilioserverlessrc'), 'w')
+      );
+      const result = await createServerlessConfigFile(basePath);
+      expect(result).toBe(false);
+
+      const contents = fs.readFileSync(
+        path.join(basePath, '.twilioserverlessrc'),
+        {
+          encoding: 'utf-8',
+        }
+      );
+      expect(contents.startsWith('{')).toBe(false);
       cleanUp();
     });
   });

--- a/packages/create-twilio-function/tests/create-twilio-function.test.js
+++ b/packages/create-twilio-function/tests/create-twilio-function.test.js
@@ -161,6 +161,10 @@ describe('createTwilioFunction', () => {
         expect(env.isFile());
         const nvmrc = await stat(path.join(scratchDir, name, '.nvmrc'));
         expect(nvmrc.isFile());
+        const serverlessrc = await stat(
+          path.join(scratchDir, name, '.twilioserverlessrc')
+        );
+        expect(serverlessrc.isFile());
 
         const packageJSON = await stat(
           path.join(scratchDir, name, 'package.json')

--- a/packages/twilio-run/__tests__/config/global.test.ts
+++ b/packages/twilio-run/__tests__/config/global.test.ts
@@ -23,6 +23,23 @@ describe('readSpecializedConfig', () => {
     });
   });
 
+  test('deletes unwanted keys from config', () => {
+    __setTestConfig({
+      serviceSid: 'ZS11112222111122221111222211112222',
+      env: '.env.example',
+      username: 'hello',
+      password: 'bye',
+      config: 'configfile',
+    });
+
+    expect(
+      readSpecializedConfig('/tmp', '.twilioserverlessrc', 'deploy')
+    ).toEqual({
+      serviceSid: 'ZS11112222111122221111222211112222',
+      env: '.env.example',
+    });
+  });
+
   test('merges command-specific config', () => {
     __setTestConfig({
       serviceSid: 'ZS11112222111122221111222211112222',

--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -8,7 +8,6 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"assets\\": true 	/* Upload assets. Can be turned off with --no-assets */,
 	// \\"assetsFolder\\": null 	/* Specific folder name to be used for static assets */,
 	// \\"buildSid\\": null 	/* An existing Build SID to deploy to the new environment */,
-	// \\"config\\": null 	/* Location of the config file. Absolute path or relative to current working directory (cwd) */,
 	// \\"createEnvironment\\": false 	/* Creates environment if it couldn't find it. */,
 	// \\"cwd\\": null 	/* Sets the directory of your existing Serverless project. Defaults to current directory */,
 	// \\"detailedLogs\\": false 	/* Toggles detailed request logging by showing request body and query params */,
@@ -33,7 +32,6 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"ngrok\\": null 	/* Uses ngrok to create a public url. Pass a string to set the subdomain (requires a paid-for ngrok account). */,
 	// \\"outputFormat\\": \\"\\" 	/* Output the log in a different format */,
 	// \\"overrideExistingProject\\": false 	/* Deploys Serverless project to existing service if a naming conflict has been found. */,
-	// \\"password\\": null 	/* A specific API secret or auth token for deployment. Uses fields from .env otherwise */,
 	// \\"port\\": \\"3000\\" 	/* Override default port of 3000 */,
 	// \\"production\\": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,
 	// \\"properties\\": null 	/* Specify the output properties you want to see. Works best on single types */,
@@ -44,6 +42,5 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"sourceEnvironment\\": null 	/* SID or suffix of an existing environment you want to deploy from. */,
 	// \\"tail\\": false 	/* Continuously stream the logs */,
 	// \\"template\\": null 	/* undefined */,
-	// \\"username\\": null 	/* A specific API key or account SID to be used for deployment. Uses fields in .env otherwise */,
 }"
 `;

--- a/packages/twilio-run/src/config/global.ts
+++ b/packages/twilio-run/src/config/global.ts
@@ -9,6 +9,8 @@ export type SpecializedConfigOptions = {
   environmentSuffix: string;
 };
 
+export const EXCLUDED_FLAGS = ['username', 'password', 'config'];
+
 export function readSpecializedConfig<T extends CommandConfigurationNames>(
   baseDir: string,
   configFileName: string,
@@ -66,6 +68,10 @@ export function readSpecializedConfig<T extends CommandConfigurationNames>(
       ...projectsConfig[opts.username],
     };
   }
+
+  EXCLUDED_FLAGS.forEach((key) => {
+    delete (result as any)[key];
+  });
 
   return result;
 }

--- a/packages/twilio-run/src/templating/defaultConfig.ts
+++ b/packages/twilio-run/src/templating/defaultConfig.ts
@@ -2,6 +2,7 @@ import camelCase from 'lodash.camelcase';
 import os from 'os';
 import path from 'path';
 import { Options } from 'yargs';
+import { EXCLUDED_FLAGS } from '../config/global';
 import { ALL_FLAGS } from '../flags';
 import { fileExists, writeFile } from '../utils/fs';
 import { getDebugFunction } from '../utils/logger';
@@ -32,6 +33,7 @@ function templateFlagAsConfig([flag, config]: [string, Options]) {
 
 export function templateDefaultConfigFile() {
   const lines = Object.entries(ALL_FLAGS)
+    .filter(([name]) => !EXCLUDED_FLAGS.includes(name))
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(templateFlagAsConfig)
     .join(os.EOL);


### PR DESCRIPTION
By default we'll generate now a .twilioserverlessrc file with every new project

fix #244<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
