### PR TITLE
fix(plugin-serverless): add alias support

### DIFF
--- a/packages/plugin-serverless/src/commands/serverless/deploy.js
+++ b/packages/plugin-serverless/src/commands/serverless/deploy.js
@@ -1,23 +1,25 @@
-const { TwilioClientCommand } = require("@twilio/cli-core").baseCommands;
+const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 
 const {
   handler,
   cliInfo,
   describe,
-} = require("twilio-run/dist/commands/deploy");
+} = require('twilio-run/dist/commands/deploy');
 const {
   convertYargsOptionsToOclifFlags,
   normalizeFlags,
   createExternalCliOptions,
   getRegionAndEdge,
-} = require("../../utils");
+} = require('../../utils');
+
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
 
 class FunctionsDeploy extends TwilioClientCommand {
   async run() {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsDeploy);
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 
@@ -32,9 +34,8 @@ class FunctionsDeploy extends TwilioClientCommand {
 
 FunctionsDeploy.description = describe;
 
-FunctionsDeploy.flags = Object.assign(
-  convertYargsOptionsToOclifFlags(cliInfo.options),
-  { profile: TwilioClientCommand.flags.profile }
-);
+FunctionsDeploy.flags = Object.assign(flags, {
+  profile: TwilioClientCommand.flags.profile,
+});
 
 module.exports = FunctionsDeploy;

--- a/packages/plugin-serverless/src/commands/serverless/init.js
+++ b/packages/plugin-serverless/src/commands/serverless/init.js
@@ -10,12 +10,14 @@ const {
   normalizeFlags,
 } = require('../../utils');
 
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
+
 class FunctionsInit extends TwilioClientCommand {
   async run() {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsInit);
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const opts = Object.assign({}, flags, args);
     opts.accountSid = flags.accountSid || this.twilioClient.accountSid;
@@ -38,10 +40,8 @@ FunctionsInit.args = [
   },
 ];
 
-FunctionsInit.flags = Object.assign(
-  {},
-  convertYargsOptionsToOclifFlags(cliInfo.options),
-  { profile: TwilioClientCommand.flags.profile }
-);
+FunctionsInit.flags = Object.assign({}, flags, {
+  profile: TwilioClientCommand.flags.profile,
+});
 
 module.exports = FunctionsInit;

--- a/packages/plugin-serverless/src/commands/serverless/list-templates.js
+++ b/packages/plugin-serverless/src/commands/serverless/list-templates.js
@@ -10,10 +10,12 @@ const {
   normalizeFlags,
 } = require('../../utils');
 
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
+
 class FunctionsListTemplates extends Command {
   async run() {
     let { flags, args } = this.parse(FunctionsListTemplates);
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const opts = Object.assign({}, flags, args);
     return handler(opts, undefined);
@@ -24,8 +26,6 @@ FunctionsListTemplates.description = describe;
 
 FunctionsListTemplates.args = [];
 
-FunctionsListTemplates.flags = Object.assign(
-  convertYargsOptionsToOclifFlags(cliInfo.options)
-);
+FunctionsListTemplates.flags = Object.assign(flags);
 
 module.exports = FunctionsListTemplates;

--- a/packages/plugin-serverless/src/commands/serverless/list.js
+++ b/packages/plugin-serverless/src/commands/serverless/list.js
@@ -1,19 +1,21 @@
-const { TwilioClientCommand } = require("@twilio/cli-core").baseCommands;
+const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 
-const { handler, cliInfo, describe } = require("twilio-run/dist/commands/list");
+const { handler, cliInfo, describe } = require('twilio-run/dist/commands/list');
 const {
   convertYargsOptionsToOclifFlags,
   normalizeFlags,
   createExternalCliOptions,
   getRegionAndEdge,
-} = require("../../utils");
+} = require('../../utils');
+
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
 
 class FunctionsList extends TwilioClientCommand {
   async run() {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsList);
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 
@@ -30,17 +32,16 @@ FunctionsList.description = describe;
 
 FunctionsList.args = [
   {
-    name: "types",
+    name: 'types',
     required: false,
     default: cliInfo.argsDefaults.types,
     description:
-      "Comma separated list of things to list (services,environments,functions,assets,variables)",
+      'Comma separated list of things to list (services,environments,functions,assets,variables)',
   },
 ];
 
-FunctionsList.flags = Object.assign(
-  convertYargsOptionsToOclifFlags(cliInfo.options),
-  { profile: TwilioClientCommand.flags.profile }
-);
+FunctionsList.flags = Object.assign(flags, {
+  profile: TwilioClientCommand.flags.profile,
+});
 
 module.exports = FunctionsList;

--- a/packages/plugin-serverless/src/commands/serverless/logs.js
+++ b/packages/plugin-serverless/src/commands/serverless/logs.js
@@ -1,20 +1,22 @@
-const { TwilioClientCommand } = require("@twilio/cli-core").baseCommands;
+const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 
-const { handler, cliInfo, describe } = require("twilio-run/dist/commands/logs");
+const { handler, cliInfo, describe } = require('twilio-run/dist/commands/logs');
 
 const {
   convertYargsOptionsToOclifFlags,
   normalizeFlags,
   createExternalCliOptions,
   getRegionAndEdge,
-} = require("../../utils");
+} = require('../../utils');
+
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
 
 class LogsList extends TwilioClientCommand {
   async run() {
     await super.run();
 
     let { flags, args } = this.parse(LogsList);
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 
@@ -31,9 +33,8 @@ LogsList.description = describe;
 
 LogsList.args = [];
 
-LogsList.flags = Object.assign(
-  convertYargsOptionsToOclifFlags(cliInfo.options),
-  { profile: TwilioClientCommand.flags.profile }
-);
+LogsList.flags = Object.assign(flags, {
+  profile: TwilioClientCommand.flags.profile,
+});
 
 module.exports = LogsList;

--- a/packages/plugin-serverless/src/commands/serverless/new.js
+++ b/packages/plugin-serverless/src/commands/serverless/new.js
@@ -6,10 +6,12 @@ const {
   normalizeFlags,
 } = require('../../utils');
 
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
+
 class FunctionsNew extends Command {
   async run() {
     let { flags, args } = this.parse(FunctionsNew);
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const opts = Object.assign({}, flags, args);
     return handler(opts, undefined);
@@ -26,8 +28,6 @@ FunctionsNew.args = [
   },
 ];
 
-FunctionsNew.flags = Object.assign(
-  convertYargsOptionsToOclifFlags(cliInfo.options)
-);
+FunctionsNew.flags = Object.assign(flags);
 
 module.exports = FunctionsNew;

--- a/packages/plugin-serverless/src/commands/serverless/promote.js
+++ b/packages/plugin-serverless/src/commands/serverless/promote.js
@@ -12,12 +12,14 @@ const {
   getRegionAndEdge,
 } = require('../../utils');
 
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
+
 class FunctionsPromote extends TwilioClientCommand {
   async run() {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsPromote);
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 
@@ -32,11 +34,9 @@ class FunctionsPromote extends TwilioClientCommand {
 
 FunctionsPromote.description = describe;
 
-FunctionsPromote.flags = Object.assign(
-  {},
-  convertYargsOptionsToOclifFlags(cliInfo.options),
-  { profile: TwilioClientCommand.flags.profile }
-);
+FunctionsPromote.flags = Object.assign({}, flags, {
+  profile: TwilioClientCommand.flags.profile,
+});
 
 FunctionsPromote.aliases = ['serverless:activate'];
 

--- a/packages/plugin-serverless/src/commands/serverless/start.js
+++ b/packages/plugin-serverless/src/commands/serverless/start.js
@@ -10,11 +10,13 @@ const {
   normalizeFlags,
 } = require('../../utils');
 
+const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
+
 class FunctionsStart extends Command {
   async run() {
     let { flags, args } = this.parse(FunctionsStart);
 
-    flags = normalizeFlags(flags);
+    flags = normalizeFlags(flags, aliasMap);
 
     const opts = Object.assign({}, flags, args);
     return handler(opts, undefined);
@@ -31,9 +33,7 @@ FunctionsStart.args = [
   },
 ];
 
-FunctionsStart.flags = Object.assign(
-  convertYargsOptionsToOclifFlags(cliInfo.options)
-);
+FunctionsStart.flags = Object.assign(flags);
 
 FunctionsStart.aliases = ['serverless:dev', 'serverless:run'];
 

--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -3,6 +3,7 @@ const camelCase = require('lodash.camelcase');
 const { flags } = require('@oclif/command');
 
 function convertYargsOptionsToOclifFlags(options) {
+  const aliasMap = new Map();
   const flagsResult = Object.keys(options).reduce((result, name) => {
     const opt = options[name];
     const flag = {
@@ -23,10 +24,10 @@ function convertYargsOptionsToOclifFlags(options) {
 
     if (opt.type === 'number') {
       opt.type = 'string';
-      flag.parse = input => parseFloat(input);
+      flag.parse = (input) => parseFloat(input);
     }
 
-    if (opt.alias) {
+    if (opt.alias && opt.alias.length === 1) {
       flag.char = opt.alias;
     }
 
@@ -35,15 +36,25 @@ function convertYargsOptionsToOclifFlags(options) {
     }
 
     result[name] = flags[opt.type](flag);
+
+    if (opt.alias && opt.alias.length > 1) {
+      result[opt.alias] = flags[opt.type](flag);
+      aliasMap.set(opt.alias, name);
+    }
+
     return result;
   }, {});
-  return flagsResult;
+  return { flags: flagsResult, aliasMap };
 }
 
-function normalizeFlags(flags) {
+function normalizeFlags(flags, aliasMap) {
   const result = Object.keys(flags).reduce((current, name) => {
-    if (name.includes('-')) {
-      const normalizedName = camelCase(name);
+    const normalizedName = name.includes('-') ? camelCase(name) : name;
+
+    if (aliasMap.has(normalizedName)) {
+      const actualName = camelCase(aliasMap.get(normalizedName));
+      current[actualName] = flags[name];
+    } else {
       current[normalizedName] = flags[name];
     }
     return current;
@@ -51,6 +62,7 @@ function normalizeFlags(flags) {
   const [, command, ...args] = process.argv;
   result.$0 = path.basename(command);
   result._ = args;
+
   return result;
 }
 


### PR DESCRIPTION
Previously only one character aliases worked since oclif doesn't support anything else. I ended up
adding steps to our normalization to "fake" alias support

fix #242

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
