### PR TITLE
fix(plugin-serverless): handle direct username/password input

### DIFF
--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -69,6 +69,17 @@ function normalizeFlags(flags, aliasMap) {
 function createExternalCliOptions(flags, twilioClient) {
   const profile = flags.profile;
 
+  if (flags.username || flags.password) {
+    return {
+      username: flags.username,
+      password: flags.password,
+      accountSid: flags.username.startsWith('AC') ? flags.username : undefined,
+      profile: undefined,
+      logLevel: undefined,
+      outputFormat: undefined,
+    };
+  }
+
   return {
     username: twilioClient.username,
     password: twilioClient.password,

--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -69,7 +69,10 @@ function normalizeFlags(flags, aliasMap) {
 function createExternalCliOptions(flags, twilioClient) {
   const profile = flags.profile;
 
-  if (flags.username || flags.password) {
+  if (
+    (typeof flags.username === 'string' && flags.username.length > 0) ||
+    (typeof flags.password === 'string' && flags.password.length > 0)
+  ) {
     return {
       username: flags.username,
       password: flags.password,


### PR DESCRIPTION
Previously if you'd call `twilio serverless:deploy` or similar commands with `--username` and
`--password` explicitly passed as API Key/Secret, it would both read the Service SID and write the
Service SID in the deployinfo cache for the Account SID that was associated with the default
profile. This change will ignore the default profile/client if username or password are passed.

BREAKING CHANGE: You have to use --username and --password effectively together if you use either

fix #261

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
