### PR TITLE
fix(twilio-run): fix upgrade script for empty legacy files

### DIFF
--- a/packages/twilio-run/bin/upgrade-config.js
+++ b/packages/twilio-run/bin/upgrade-config.js
@@ -47,24 +47,26 @@ async function run() {
     }
   }
 
-  const promptResults = await inquirer.prompt([
-    {
-      type: 'input',
-      default: accountSidForDeployInfo,
-      message: `Please enter your Twilio Account SID for your Functions Service: ${oldConfigContent.serviceSid}`,
-      name: 'accountSid',
-      validate: (input) =>
-        (input.startsWith('AC') && input.length === 34) ||
-        'Please enter a valid account SID. It should start with AC and is 34 characters long.',
-    },
-  ]);
+  const deployInfo = {};
 
-  const deployInfo = {
-    [promptResults.accountSid]: {
+  if (oldConfigContent.serviceSid) {
+    const promptResults = await inquirer.prompt([
+      {
+        type: 'input',
+        default: accountSidForDeployInfo,
+        message: `Please enter your Twilio Account SID for your Functions Service: ${oldConfigContent.serviceSid}`,
+        name: 'accountSid',
+        validate: (input) =>
+          (input.startsWith('AC') && input.length === 34) ||
+          'Please enter a valid account SID. It should start with AC and is 34 characters long.',
+      },
+    ]);
+
+    deployInfo[promptResults.accountSid] = {
       serviceSid: oldConfigContent.serviceSid,
       latestBuild: oldConfigContent.latestBuild,
-    },
-  };
+    };
+  }
 
   let hasCustomConfigPerProject = false;
   if (oldConfigContent.projects) {


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Before this change the script wouldn't be able to handle `.twilio-functions` files that were empty. For example: `{}` because it would prompt you to specify the Account SID for the the `undefined` Service SID.

This change will only prompt you when you have a top-level `serviceSid` which would not be tied to an Account SID. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
