### PR TITLE
fix(twilio-run): fix global scope in forked process

### DIFF
--- a/packages/twilio-run/src/runtime/server.ts
+++ b/packages/twilio-run/src/runtime/server.ts
@@ -17,11 +17,10 @@ import { wrapErrorInHtml } from '../utils/error-html';
 import { getDebugFunction } from '../utils/logger';
 import { createLogger } from './internal/request-logger';
 import { getRouteMap } from './internal/route-cache';
-
 import {
   constructGlobalScope,
-  functionToRoute,
   functionPathToRoute,
+  functionToRoute,
 } from './route';
 
 const debug = getDebugFunction('twilio-run:server');
@@ -39,7 +38,7 @@ function requireCacheCleaner(
   next: NextFunction
 ) {
   debug('Deleting require cache');
-  Object.keys(require.cache).forEach(key => {
+  Object.keys(require.cache).forEach((key) => {
     // Entries in the cache that end with .node are compiled binaries, deleting
     // those has unspecified results, so we keep them.
     // Entries in the cache that include "twilio-run" are part of this module
@@ -118,11 +117,11 @@ export async function createServer(
     const debouncedReloadRoutes = debounce(reloadRoutes, RELOAD_DEBOUNCE_MS);
 
     watcher
-      .on('add', path => {
+      .on('add', (path) => {
         debug(`Reloading Routes: add @ ${path}`);
         debouncedReloadRoutes();
       })
-      .on('unlink', path => {
+      .on('unlink', (path) => {
         debug(`Reloading Routes: unlink @ ${path}`);
         debouncedReloadRoutes();
       });
@@ -168,18 +167,18 @@ export async function createServer(
             throw new Error('Missing function path');
           }
 
-          debug('Load & route to function at "%s"', functionPath);
-          const twilioFunction = loadTwilioFunction(functionPath);
-          if (typeof twilioFunction !== 'function') {
-            return res
-              .status(404)
-              .send(
-                `Could not find a "handler" function in file ${functionPath}`
-              );
-          }
           if (config.forkProcess) {
             functionPathToRoute(functionPath, config)(req, res, next);
           } else {
+            debug('Load & route to function at "%s"', functionPath);
+            const twilioFunction = loadTwilioFunction(functionPath);
+            if (typeof twilioFunction !== 'function') {
+              return res
+                .status(404)
+                .send(
+                  `Could not find a "handler" function in file ${functionPath}`
+                );
+            }
             functionToRoute(twilioFunction, config, functionPath)(
               req,
               res,
@@ -217,7 +216,7 @@ export async function runServer(
   config: StartCliConfig
 ): Promise<Express> {
   const app = await createServer(port, config);
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     app.listen(port);
     resolve(app);
   });


### PR DESCRIPTION
We were requiring the respective Function file before the global scope was created. If a user was
referencing a global object such as `Runtime` outside of the `handler` function it would throw an
UnhandledPromiseException because the Runtime wasn't constructed yet. This change only requires the
Function right before execution. This will also create more accurate timing results for cold starts.

During the fix I realized that the Function was also required twice, once by the Server and once by
the forked process. The server should only require the Function if it's not a forked process.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
