### PR TITLE
fix(plugin-serverless): remove default from aliases

### DIFF
--- a/packages/plugin-serverless/jest.config.js
+++ b/packages/plugin-serverless/jest.config.js
@@ -1,0 +1,10 @@
+const base = require('../../jest.config.base.js');
+const { join } = require('path');
+
+module.exports = {
+  ...base,
+  preset: null,
+  name: 'plugin-serverless',
+  displayName: 'plugin-serverless',
+  globalTeardown: join(__dirname, 'jest.teardown.js'),
+};

--- a/packages/plugin-serverless/jest.teardown.js
+++ b/packages/plugin-serverless/jest.teardown.js
@@ -1,0 +1,7 @@
+const { join } = require('path');
+const { tmpdir } = require('os');
+const rimraf = require('rimraf');
+
+module.exports = () => {
+  rimraf.sync(join(tmpdir(), 'scratch'));
+};

--- a/packages/plugin-serverless/src/commands/serverless/deploy.js
+++ b/packages/plugin-serverless/src/commands/serverless/deploy.js
@@ -19,7 +19,7 @@ class FunctionsDeploy extends TwilioClientCommand {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsDeploy);
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 

--- a/packages/plugin-serverless/src/commands/serverless/init.js
+++ b/packages/plugin-serverless/src/commands/serverless/init.js
@@ -17,7 +17,7 @@ class FunctionsInit extends TwilioClientCommand {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsInit);
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const opts = Object.assign({}, flags, args);
     opts.accountSid = flags.accountSid || this.twilioClient.accountSid;

--- a/packages/plugin-serverless/src/commands/serverless/list-templates.js
+++ b/packages/plugin-serverless/src/commands/serverless/list-templates.js
@@ -15,7 +15,7 @@ const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
 class FunctionsListTemplates extends Command {
   async run() {
     let { flags, args } = this.parse(FunctionsListTemplates);
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const opts = Object.assign({}, flags, args);
     return handler(opts, undefined);

--- a/packages/plugin-serverless/src/commands/serverless/list.js
+++ b/packages/plugin-serverless/src/commands/serverless/list.js
@@ -15,7 +15,7 @@ class FunctionsList extends TwilioClientCommand {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsList);
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 

--- a/packages/plugin-serverless/src/commands/serverless/logs.js
+++ b/packages/plugin-serverless/src/commands/serverless/logs.js
@@ -16,7 +16,7 @@ class LogsList extends TwilioClientCommand {
     await super.run();
 
     let { flags, args } = this.parse(LogsList);
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 

--- a/packages/plugin-serverless/src/commands/serverless/new.js
+++ b/packages/plugin-serverless/src/commands/serverless/new.js
@@ -11,7 +11,7 @@ const { flags, aliasMap } = convertYargsOptionsToOclifFlags(cliInfo.options);
 class FunctionsNew extends Command {
   async run() {
     let { flags, args } = this.parse(FunctionsNew);
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const opts = Object.assign({}, flags, args);
     return handler(opts, undefined);

--- a/packages/plugin-serverless/src/commands/serverless/promote.js
+++ b/packages/plugin-serverless/src/commands/serverless/promote.js
@@ -19,7 +19,7 @@ class FunctionsPromote extends TwilioClientCommand {
     await super.run();
 
     let { flags, args } = this.parse(FunctionsPromote);
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const externalOptions = createExternalCliOptions(flags, this.twilioClient);
 

--- a/packages/plugin-serverless/src/commands/serverless/start.js
+++ b/packages/plugin-serverless/src/commands/serverless/start.js
@@ -16,7 +16,7 @@ class FunctionsStart extends Command {
   async run() {
     let { flags, args } = this.parse(FunctionsStart);
 
-    flags = normalizeFlags(flags, aliasMap);
+    flags = normalizeFlags(flags, aliasMap, process.argv);
 
     const opts = Object.assign({}, flags, args);
     return handler(opts, undefined);

--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -38,7 +38,12 @@ function convertYargsOptionsToOclifFlags(options) {
     result[name] = flags[opt.type](flag);
 
     if (opt.alias && opt.alias.length > 1) {
-      result[opt.alias] = flags[opt.type](flag);
+      result[opt.alias] = flags[opt.type]({
+        ...flag,
+        default: undefined,
+        description: `[Alias for "${name}"]`,
+        required: undefined,
+      });
       aliasMap.set(opt.alias, name);
     }
 
@@ -47,7 +52,7 @@ function convertYargsOptionsToOclifFlags(options) {
   return { flags: flagsResult, aliasMap };
 }
 
-function normalizeFlags(flags, aliasMap) {
+function normalizeFlags(flags, aliasMap, argv) {
   const result = Object.keys(flags).reduce((current, name) => {
     const normalizedName = name.includes('-') ? camelCase(name) : name;
 
@@ -59,7 +64,7 @@ function normalizeFlags(flags, aliasMap) {
     }
     return current;
   }, flags);
-  const [, command, ...args] = process.argv;
+  const [, command, ...args] = argv;
   result.$0 = path.basename(command);
   result._ = args;
 

--- a/packages/plugin-serverless/tests/utils.test.js
+++ b/packages/plugin-serverless/tests/utils.test.js
@@ -1,0 +1,281 @@
+const { flags } = require('@oclif/command');
+const {
+  normalizeFlags,
+  convertYargsOptionsToOclifFlags,
+} = require('../src/utils');
+
+describe('normalizeFlags', () => {
+  let baseArgv = ['', '/some/path/twilio', 'serverless:deploy', 'test'];
+  const baseOutput = {
+    $0: 'twilio',
+    _: ['serverless:deploy', 'test'],
+  };
+
+  beforeEach(() => {
+    baseArgv = ['', '/some/path/twilio', 'serverless:deploy', 'test'];
+  });
+
+  test('converts kebabcase to camelcase', () => {
+    const input = {
+      'source-environment': 'dev',
+      environment: 'prod',
+    };
+    const aliasMap = new Map();
+
+    const output = normalizeFlags(input, aliasMap, baseArgv);
+    expect(output).toEqual({
+      ...baseOutput,
+      sourceEnvironment: 'dev',
+      'source-environment': 'dev',
+      environment: 'prod',
+    });
+  });
+
+  test('handles aliases correctly if no alias is used', () => {
+    const input = {
+      'source-environment': 'dev',
+      environment: 'prod',
+    };
+    const aliasMap = new Map();
+    aliasMap.set('to', 'environment');
+
+    const output = normalizeFlags(input, aliasMap, baseArgv);
+    expect(output).toEqual({
+      ...baseOutput,
+      sourceEnvironment: 'dev',
+      'source-environment': 'dev',
+      environment: 'prod',
+    });
+  });
+
+  test('handles aliases correctly', () => {
+    const input = {
+      'source-environment': 'dev',
+      to: 'prod',
+    };
+    const aliasMap = new Map();
+    aliasMap.set('to', 'environment');
+
+    const output = normalizeFlags(input, aliasMap, baseArgv);
+    expect(output).toEqual({
+      ...baseOutput,
+      sourceEnvironment: 'dev',
+      'source-environment': 'dev',
+      to: 'prod',
+      environment: 'prod',
+    });
+  });
+});
+
+describe('convertYargsOptionsToOclifFlags', () => {
+  test('should convert basic yargs flag definitions to Oclif', () => {
+    const yargsFlags = {
+      'service-sid': {
+        type: 'string',
+        describe: 'SID of the Twilio Serverless Service to deploy to',
+      },
+      production: {
+        type: 'boolean',
+        describe:
+          'Promote build to the production environment (no domain suffix). Overrides environment flag',
+        default: false,
+      },
+    };
+
+    const result = convertYargsOptionsToOclifFlags(yargsFlags);
+    expect(result.aliasMap.size).toEqual(0);
+    expect(result.flags.toString()).toEqual(
+      {
+        production: flags.boolean({
+          description: yargsFlags.production.describe,
+          default: yargsFlags.production.default,
+          hidden: undefined,
+        }),
+        'service-sid': flags.string({
+          description: yargsFlags['service-sid'].describe,
+          default: yargsFlags['service-sid'].default,
+          hidden: undefined,
+        }),
+      }.toString()
+    );
+  });
+
+  test('should handle required arguments', () => {
+    const yargsFlags = {
+      'service-sid': {
+        type: 'string',
+        describe: 'SID of the Twilio Serverless Service to deploy to',
+        requiresArg: true,
+      },
+      production: {
+        type: 'boolean',
+        describe:
+          'Promote build to the production environment (no domain suffix). Overrides environment flag',
+        default: false,
+      },
+    };
+
+    const result = convertYargsOptionsToOclifFlags(yargsFlags);
+    expect(result.aliasMap.size).toEqual(0);
+    expect(result.flags.toString()).toEqual(
+      {
+        production: flags.boolean({
+          description: yargsFlags.production.describe,
+          default: yargsFlags.production.default,
+          hidden: undefined,
+        }),
+        'service-sid': flags.string({
+          description: yargsFlags['service-sid'].describe,
+          default: yargsFlags['service-sid'].default,
+          hidden: undefined,
+          required: true,
+        }),
+      }.toString()
+    );
+  });
+
+  test('should handle numbers', () => {
+    const yargsFlags = {
+      port: {
+        type: 'number',
+        describe: 'the port to listen on',
+      },
+      production: {
+        type: 'boolean',
+        describe:
+          'Promote build to the production environment (no domain suffix). Overrides environment flag',
+        default: false,
+      },
+    };
+
+    const result = convertYargsOptionsToOclifFlags(yargsFlags);
+    expect(result.aliasMap.size).toEqual(0);
+    expect(result.flags.toString()).toEqual(
+      {
+        production: flags.boolean({
+          description: yargsFlags.production.describe,
+          default: yargsFlags.production.default,
+          hidden: undefined,
+        }),
+        port: flags.string({
+          description: yargsFlags.port.describe,
+          default: yargsFlags.port.default,
+          hidden: undefined,
+        }),
+      }.toString()
+    );
+    expect(result.flags.port.parse('8000')).toEqual(8000);
+  });
+
+  test('should handle single letter aliases', () => {
+    const yargsFlags = {
+      'service-sid': {
+        type: 'string',
+        describe: 'SID of the Twilio Serverless Service to deploy to',
+      },
+      production: {
+        type: 'boolean',
+        describe:
+          'Promote build to the production environment (no domain suffix). Overrides environment flag',
+        default: false,
+      },
+      username: {
+        type: 'string',
+        alias: 'u',
+        describe:
+          'A specific API key or account SID to be used for deployment. Uses fields in .env otherwise',
+      },
+    };
+
+    const result = convertYargsOptionsToOclifFlags(yargsFlags);
+    expect(result.aliasMap.size).toEqual(0);
+    expect(result.flags.toString()).toEqual(
+      {
+        production: flags.boolean({
+          description: yargsFlags.production.describe,
+          default: yargsFlags.production.default,
+          hidden: undefined,
+        }),
+        'service-sid': flags.string({
+          description: yargsFlags['service-sid'].describe,
+          default: yargsFlags['service-sid'].default,
+          hidden: undefined,
+        }),
+        username: flags.string({
+          description: yargsFlags['username'].describe,
+          default: yargsFlags['username'].default,
+          hidden: undefined,
+          char: 'u',
+        }),
+      }.toString()
+    );
+  });
+
+  test('should handle long-form aliases', () => {
+    const yargsFlags = {
+      'service-sid': {
+        type: 'string',
+        describe: 'SID of the Twilio Serverless Service to deploy to',
+      },
+      production: {
+        type: 'boolean',
+        describe:
+          'Promote build to the production environment (no domain suffix). Overrides environment flag',
+        default: false,
+      },
+      'source-environment': {
+        type: 'string',
+        alias: 'from',
+        describe:
+          'SID or suffix of an existing environment you want to deploy from.',
+      },
+      environment: {
+        type: 'string',
+        alias: 'to',
+        describe:
+          'The environment name (domain suffix) you want to use for your deployment',
+        default: 'dev',
+      },
+    };
+
+    const result = convertYargsOptionsToOclifFlags(yargsFlags);
+    expect([...result.aliasMap.entries()]).toEqual([
+      ['from', 'source-environment'],
+      ['to', 'environment'],
+    ]);
+    expect(result.flags.toString()).toEqual(
+      {
+        production: flags.boolean({
+          description: yargsFlags.production.describe,
+          default: yargsFlags.production.default,
+          hidden: undefined,
+        }),
+        'service-sid': flags.string({
+          description: yargsFlags['service-sid'].describe,
+          default: yargsFlags['service-sid'].default,
+          hidden: undefined,
+        }),
+        'source-environment': flags.string({
+          description: yargsFlags['source-environment'].describe,
+          default: yargsFlags['source-environment'].default,
+          hidden: undefined,
+        }),
+        from: flags.string({
+          description: '[Alias for "source-environment"]',
+          default: undefined,
+          hidden: undefined,
+        }),
+        environment: flags.string({
+          description: yargsFlags['environment'].describe,
+          default: yargsFlags['environment'].default,
+          hidden: undefined,
+        }),
+        to: flags.string({
+          description: '[Alias for "environment"]',
+          default: undefined,
+          hidden: undefined,
+        }),
+      }.toString()
+    );
+  });
+});


### PR DESCRIPTION
The recent introduction of alias support in the `plugin-serverless` was causing issues if there was
a default value as the default value of the alias would override the value explicitly passed into
the original command. This change removes default and required arguments from aliases and also
explicitly updates the description.

fix #272

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
