### PR TITLE
fix(serverless-api): do not retry for HTTP client request errors

### DIFF
--- a/packages/serverless-api/src/client.ts
+++ b/packages/serverless-api/src/client.ts
@@ -343,13 +343,8 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
    */
   async activateBuild(activateConfig: ActivateConfig): Promise<ActivateResult> {
     try {
-      let {
-        buildSid,
-        targetEnvironment,
-        serviceSid,
-        sourceEnvironment,
-        env,
-      } = activateConfig;
+      let { buildSid, targetEnvironment, serviceSid, sourceEnvironment, env } =
+        activateConfig;
 
       if (!buildSid && !sourceEnvironment) {
         const error = new Error(
@@ -688,6 +683,7 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
       limit: this.config.retryLimit || RETRY_LIMIT,
       methods: ['GET', 'POST', 'DELETE'],
       statusCodes: [429],
+      errorCodes: [],
     };
     return this.limit(() => this.client[method](path, options));
   }


### PR DESCRIPTION
Fixes #284

When you run `twilio serverless:deploy --region au1` with this patch it now fails like this:

<img width="445" alt="Failed deployment. Error. getaddrinfo ENOTFOUND serverless.au1.twilio.com" src="https://user-images.githubusercontent.com/31462/123053124-eb92d580-d446-11eb-8e72-d236ab18f9f5.png">

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
