### PR TITLE
feat(plugin-assets): adds flag for setting service name in init

### DIFF
--- a/packages/plugin-assets/package.json
+++ b/packages/plugin-assets/package.json
@@ -12,7 +12,8 @@
     "@twilio-labs/serverless-api": "^5.1.0",
     "@twilio/cli-core": "^5.22.0",
     "inquirer": "^8.0.0",
-    "ora": "^5.4.0"
+    "ora": "^5.4.0",
+    "project-name-generator": "^2.1.9"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",

--- a/packages/plugin-assets/src/commands/assets/init.js
+++ b/packages/plugin-assets/src/commands/assets/init.js
@@ -9,7 +9,6 @@ class InitCommand extends TwilioClientCommand {
   async run() {
     await super.run();
     try {
-      const { flags } = this.parse(InitCommand);
       const pluginConfig = getPluginConfig(this);
       const result = await init({
         apiKey: this.currentProfile.apiKey,
@@ -17,7 +16,7 @@ class InitCommand extends TwilioClientCommand {
         accountSid: this.currentProfile.accountSid,
         pluginConfig: pluginConfig,
         logger: this.logger,
-        serviceName: flags['service-name'],
+        serviceName: this.flags['service-name'],
       });
       this.output(result, this.flags.properties);
     } catch (error) {

--- a/packages/plugin-assets/src/commands/assets/init.js
+++ b/packages/plugin-assets/src/commands/assets/init.js
@@ -1,12 +1,15 @@
 const { flags } = require('@oclif/command');
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 const { getPluginConfig } = require('../../pluginConfig');
+const generateProjectName = require('project-name-generator');
+
 const { init } = require('../../init');
 
 class InitCommand extends TwilioClientCommand {
   async run() {
     await super.run();
     try {
+      const { flags } = this.parse(InitCommand);
       const pluginConfig = getPluginConfig(this);
       const result = await init({
         apiKey: this.currentProfile.apiKey,
@@ -14,6 +17,7 @@ class InitCommand extends TwilioClientCommand {
         accountSid: this.currentProfile.accountSid,
         pluginConfig: pluginConfig,
         logger: this.logger,
+        serviceName: flags['service-name'],
       });
       this.output(result, this.flags.properties);
     } catch (error) {
@@ -23,6 +27,11 @@ class InitCommand extends TwilioClientCommand {
 }
 
 InitCommand.flags = {
+  'service-name': flags.string({
+    description:
+      'A unique name for your asset service. May only contain alphanumeric characters and hyphens.',
+    default: () => generateProjectName().dashed,
+  }),
   properties: flags.string({
     default: 'service_sid, sid, domain_name',
     description:

--- a/packages/plugin-assets/src/commands/assets/list.js
+++ b/packages/plugin-assets/src/commands/assets/list.js
@@ -6,7 +6,6 @@ const { list } = require('../../list');
 class ListCommand extends TwilioClientCommand {
   async run() {
     await super.run();
-
     try {
       const pluginConfig = getPluginConfig(this);
       const assets = await list({

--- a/packages/plugin-assets/src/commands/assets/upload.js
+++ b/packages/plugin-assets/src/commands/assets/upload.js
@@ -8,14 +8,13 @@ class UploadCommand extends TwilioClientCommand {
     await super.run();
 
     try {
-      const { args } = this.parse(UploadCommand);
       const pluginConfig = getPluginConfig(this);
       const assets = await upload({
         apiKey: this.currentProfile.apiKey,
         apiSecret: this.currentProfile.apiSecret,
         accountSid: this.currentProfile.accountSid,
         pluginConfig: pluginConfig,
-        file: args.file,
+        file: this.args.file,
         logger: this.logger,
       });
       this.output(assets, this.flags.properties);

--- a/packages/plugin-assets/tests/init.test.js
+++ b/packages/plugin-assets/tests/init.test.js
@@ -30,8 +30,6 @@ const mockLogger = {
   debug: jest.fn(),
 };
 
-const configPath = path.join(tmpdir(), 'scratch', 'plugin-assets-config.json');
-
 describe('init', () => {
   describe('with nothing in the config', () => {
     const fakeConfig = {
@@ -45,6 +43,7 @@ describe('init', () => {
         accountSid: 'test-account-sid',
         pluginConfig: fakeConfig,
         logger: mockLogger,
+        serviceName: 'test-asset-service',
       });
 
       expect(createEnvironmentFromSuffix).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Also generates random project name to avoid all services being called the same thing.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
