### PR TITLE
fix(response): brings Response object to parity with Functions

### DIFF
--- a/packages/runtime-handler/__tests__/dev-runtime/internal/response.test.ts
+++ b/packages/runtime-handler/__tests__/dev-runtime/internal/response.test.ts
@@ -3,31 +3,52 @@ import { Response } from '../../../src/dev-runtime/internal/response';
 
 test('has correct defaults', () => {
   const response = new Response();
-  expect(response['body']).toBeUndefined();
+  expect(response['body']).toBeNull();
   expect(response['statusCode']).toBe(200);
   expect(response['headers']).toEqual({});
+});
+
+test('sets status code, body and headers from constructor', () => {
+  const response = new Response({
+    headers: {
+      'Access-Control-Allow-Origin': 'example.com',
+      'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+    body: 'Error',
+    statusCode: 400,
+  });
+  expect(response['statusCode']).toBe(400);
+  expect(response['body']).toBe('Error');
+  expect(response['headers']).toEqual({
+    'Access-Control-Allow-Origin': 'example.com',
+    'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
 });
 
 test('sets status code', () => {
   const response = new Response();
   expect(response['statusCode']).toBe(200);
-  response.setStatusCode(418);
+  const response2 = response.setStatusCode(418);
   expect(response['statusCode']).toBe(418);
+  expect(response2).toBe(response);
 });
 
 test('sets body correctly', () => {
   const response = new Response();
-  expect(response['body']).toBeUndefined();
+  expect(response['body']).toBeNull();
   response.setBody('Hello');
   expect(response['body']).toBe('Hello');
-  response.setBody({ url: 'https://dkundel.com' });
+  const response2 = response.setBody({ url: 'https://dkundel.com' });
   expect(response['body']).toEqual({ url: 'https://dkundel.com' });
+  expect(response2).toBe(response);
 });
 
 test('sets headers correctly', () => {
   const response = new Response();
   expect(response['headers']).toEqual({});
-  response.setHeaders({
+  const response2 = response.setHeaders({
     'Access-Control-Allow-Origin': 'example.com',
     'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
     'Access-Control-Allow-Headers': 'Content-Type',
@@ -41,6 +62,7 @@ test('sets headers correctly', () => {
   // @ts-ignore
   response.setHeaders(undefined);
   expect(response['headers']).toEqual(expected);
+  expect(response2).toBe(response);
 });
 
 test('appends a new header correctly', () => {
@@ -50,11 +72,12 @@ test('appends a new header correctly', () => {
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
-  response.appendHeader('Content-Type', 'application/json');
+  const response2 = response.appendHeader('Content-Type', 'application/json');
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
     'Content-Type': 'application/json',
   });
+  expect(response2).toBe(response);
 });
 
 test('appends a header correctly with no existing one', () => {
@@ -62,10 +85,14 @@ test('appends a header correctly with no existing one', () => {
   expect(response['headers']).toEqual({});
   // @ts-ignore
   response['headers'] = undefined;
-  response.appendHeader('Access-Control-Allow-Origin', 'dkundel.com');
+  const response2 = response.appendHeader(
+    'Access-Control-Allow-Origin',
+    'dkundel.com'
+  );
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
+  expect(response2).toBe(response);
 });
 
 test('calls express response correctly', () => {

--- a/packages/runtime-handler/__tests__/dev-runtime/internal/response.test.ts
+++ b/packages/runtime-handler/__tests__/dev-runtime/internal/response.test.ts
@@ -30,9 +30,8 @@ test('sets status code, body and headers from constructor', () => {
 test('sets status code', () => {
   const response = new Response();
   expect(response['statusCode']).toBe(200);
-  const response2 = response.setStatusCode(418);
+  response.setStatusCode(418);
   expect(response['statusCode']).toBe(418);
-  expect(response2).toBe(response);
 });
 
 test('sets body correctly', () => {
@@ -40,15 +39,14 @@ test('sets body correctly', () => {
   expect(response['body']).toBeNull();
   response.setBody('Hello');
   expect(response['body']).toBe('Hello');
-  const response2 = response.setBody({ url: 'https://dkundel.com' });
+  response.setBody({ url: 'https://dkundel.com' });
   expect(response['body']).toEqual({ url: 'https://dkundel.com' });
-  expect(response2).toBe(response);
 });
 
 test('sets headers correctly', () => {
   const response = new Response();
   expect(response['headers']).toEqual({});
-  const response2 = response.setHeaders({
+  response.setHeaders({
     'Access-Control-Allow-Origin': 'example.com',
     'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
     'Access-Control-Allow-Headers': 'Content-Type',
@@ -62,7 +60,6 @@ test('sets headers correctly', () => {
   // @ts-ignore
   response.setHeaders(undefined);
   expect(response['headers']).toEqual(expected);
-  expect(response2).toBe(response);
 });
 
 test('appends a new header correctly', () => {
@@ -72,12 +69,11 @@ test('appends a new header correctly', () => {
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
-  const response2 = response.appendHeader('Content-Type', 'application/json');
+  response.appendHeader('Content-Type', 'application/json');
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
     'Content-Type': 'application/json',
   });
-  expect(response2).toBe(response);
 });
 
 test('appends a header correctly with no existing one', () => {
@@ -85,14 +81,30 @@ test('appends a header correctly with no existing one', () => {
   expect(response['headers']).toEqual({});
   // @ts-ignore
   response['headers'] = undefined;
-  const response2 = response.appendHeader(
-    'Access-Control-Allow-Origin',
-    'dkundel.com'
-  );
+  response.appendHeader('Access-Control-Allow-Origin', 'dkundel.com');
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
-  expect(response2).toBe(response);
+});
+
+test('setStatusCode returns the response', () => {
+  const response = new Response();
+  expect(response.setStatusCode(418)).toBe(response);
+});
+
+test('setBody returns the response', () => {
+  const response = new Response();
+  expect(response.setBody('Hello')).toBe(response);
+});
+
+test('setHeader returns the response', () => {
+  const response = new Response();
+  expect(response.setHeaders({ 'X-Test': 'Hello' })).toBe(response);
+});
+
+test('appendHeader returns the response', () => {
+  const response = new Response();
+  expect(response.appendHeader('X-Test', 'Hello')).toBe(response);
 });
 
 test('calls express response correctly', () => {

--- a/packages/runtime-handler/src/dev-runtime/internal/response.ts
+++ b/packages/runtime-handler/src/dev-runtime/internal/response.ts
@@ -4,44 +4,64 @@ import debug from '../utils/debug';
 
 const log = debug('twilio-runtime-handler:dev:response');
 
+type ResponseOptions = {
+  headers?: Headers;
+  statusCode?: number;
+  body?: object | string;
+};
+
 type HeaderValue = number | string;
 type Headers = {
   [key: string]: HeaderValue;
 };
 
 export class Response implements TwilioResponse {
-  private body: undefined | any;
+  private body: null | any;
   private statusCode: number;
   private headers: Headers;
 
-  constructor() {
-    this.body = undefined;
+  constructor(options?: ResponseOptions) {
+    this.body = null;
     this.statusCode = 200;
     this.headers = {};
+
+    if (options && options.statusCode) {
+      this.statusCode = options.statusCode;
+    }
+    if (options && options.body) {
+      this.body = options.body;
+    }
+    if (options && options.headers) {
+      this.headers = options.headers;
+    }
   }
 
-  setStatusCode(statusCode: number): void {
+  setStatusCode(statusCode: number): Response {
     log('Setting status code to %d', statusCode);
     this.statusCode = statusCode;
+    return this;
   }
 
-  setBody(body: object | string): void {
+  setBody(body: object | string): Response {
     log('Setting response body to %o', body);
     this.body = body;
+    return this;
   }
 
-  setHeaders(headersObject: Headers): void {
+  setHeaders(headersObject: Headers): Response {
     log('Setting headers to: %P', headersObject);
     if (typeof headersObject !== 'object') {
-      return;
+      return this;
     }
     this.headers = headersObject;
+    return this;
   }
 
-  appendHeader(key: string, value: HeaderValue): void {
+  appendHeader(key: string, value: HeaderValue): Response {
     log('Appending header for %s', key, value);
     this.headers = this.headers || {};
     this.headers[key] = value;
+    return this;
   }
 
   applyToExpressResponse(res: ExpressResponse): void {

--- a/packages/twilio-run/__tests__/runtime/internal/response.test.ts
+++ b/packages/twilio-run/__tests__/runtime/internal/response.test.ts
@@ -30,9 +30,8 @@ test('sets status code, body and headers from constructor', () => {
 test('sets status code', () => {
   const response = new Response();
   expect(response['statusCode']).toBe(200);
-  const response2 = response.setStatusCode(418);
+  response.setStatusCode(418);
   expect(response['statusCode']).toBe(418);
-  expect(response2).toBe(response);
 });
 
 test('sets body correctly', () => {
@@ -40,15 +39,14 @@ test('sets body correctly', () => {
   expect(response['body']).toBeNull();
   response.setBody('Hello');
   expect(response['body']).toBe('Hello');
-  const response2 = response.setBody({ url: 'https://dkundel.com' });
+  response.setBody({ url: 'https://dkundel.com' });
   expect(response['body']).toEqual({ url: 'https://dkundel.com' });
-  expect(response2).toBe(response);
 });
 
 test('sets headers correctly', () => {
   const response = new Response();
   expect(response['headers']).toEqual({});
-  const response2 = response.setHeaders({
+  response.setHeaders({
     'Access-Control-Allow-Origin': 'example.com',
     'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
     'Access-Control-Allow-Headers': 'Content-Type',
@@ -62,7 +60,6 @@ test('sets headers correctly', () => {
   // @ts-ignore
   response.setHeaders(undefined);
   expect(response['headers']).toEqual(expected);
-  expect(response2).toBe(response);
 });
 
 test('appends a new header correctly', () => {
@@ -72,12 +69,11 @@ test('appends a new header correctly', () => {
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
-  const response2 = response.appendHeader('Content-Type', 'application/json');
+  response.appendHeader('Content-Type', 'application/json');
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
     'Content-Type': 'application/json',
   });
-  expect(response2).toBe(response);
 });
 
 test('appends a header correctly with no existing one', () => {
@@ -85,14 +81,30 @@ test('appends a header correctly with no existing one', () => {
   expect(response['headers']).toEqual({});
   // @ts-ignore
   response['headers'] = undefined;
-  const response2 = response.appendHeader(
-    'Access-Control-Allow-Origin',
-    'dkundel.com'
-  );
+  response.appendHeader('Access-Control-Allow-Origin', 'dkundel.com');
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
-  expect(response2).toBe(response);
+});
+
+test('setStatusCode returns the response', () => {
+  const response = new Response();
+  expect(response.setStatusCode(418)).toBe(response);
+});
+
+test('setBody returns the response', () => {
+  const response = new Response();
+  expect(response.setBody('Hello')).toBe(response);
+});
+
+test('setHeader returns the response', () => {
+  const response = new Response();
+  expect(response.setHeaders({ 'X-Test': 'Hello' })).toBe(response);
+});
+
+test('appendHeader returns the response', () => {
+  const response = new Response();
+  expect(response.appendHeader('X-Test', 'Hello')).toBe(response);
 });
 
 test('calls express response correctly', () => {

--- a/packages/twilio-run/__tests__/runtime/internal/response.test.ts
+++ b/packages/twilio-run/__tests__/runtime/internal/response.test.ts
@@ -3,31 +3,52 @@ import { Response as ExpressResponse } from 'express';
 
 test('has correct defaults', () => {
   const response = new Response();
-  expect(response['body']).toBeUndefined();
+  expect(response['body']).toBeNull();
   expect(response['statusCode']).toBe(200);
   expect(response['headers']).toEqual({});
+});
+
+test('sets status code, body and headers from constructor', () => {
+  const response = new Response({
+    headers: {
+      'Access-Control-Allow-Origin': 'example.com',
+      'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+    body: 'Error',
+    statusCode: 400,
+  });
+  expect(response['statusCode']).toBe(400);
+  expect(response['body']).toBe('Error');
+  expect(response['headers']).toEqual({
+    'Access-Control-Allow-Origin': 'example.com',
+    'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
 });
 
 test('sets status code', () => {
   const response = new Response();
   expect(response['statusCode']).toBe(200);
-  response.setStatusCode(418);
+  const response2 = response.setStatusCode(418);
   expect(response['statusCode']).toBe(418);
+  expect(response2).toBe(response);
 });
 
 test('sets body correctly', () => {
   const response = new Response();
-  expect(response['body']).toBeUndefined();
+  expect(response['body']).toBeNull();
   response.setBody('Hello');
   expect(response['body']).toBe('Hello');
-  response.setBody({ url: 'https://dkundel.com' });
+  const response2 = response.setBody({ url: 'https://dkundel.com' });
   expect(response['body']).toEqual({ url: 'https://dkundel.com' });
+  expect(response2).toBe(response);
 });
 
 test('sets headers correctly', () => {
   const response = new Response();
   expect(response['headers']).toEqual({});
-  response.setHeaders({
+  const response2 = response.setHeaders({
     'Access-Control-Allow-Origin': 'example.com',
     'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE',
     'Access-Control-Allow-Headers': 'Content-Type',
@@ -41,6 +62,7 @@ test('sets headers correctly', () => {
   // @ts-ignore
   response.setHeaders(undefined);
   expect(response['headers']).toEqual(expected);
+  expect(response2).toBe(response);
 });
 
 test('appends a new header correctly', () => {
@@ -50,11 +72,12 @@ test('appends a new header correctly', () => {
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
-  response.appendHeader('Content-Type', 'application/json');
+  const response2 = response.appendHeader('Content-Type', 'application/json');
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
     'Content-Type': 'application/json',
   });
+  expect(response2).toBe(response);
 });
 
 test('appends a header correctly with no existing one', () => {
@@ -62,10 +85,14 @@ test('appends a header correctly with no existing one', () => {
   expect(response['headers']).toEqual({});
   // @ts-ignore
   response['headers'] = undefined;
-  response.appendHeader('Access-Control-Allow-Origin', 'dkundel.com');
+  const response2 = response.appendHeader(
+    'Access-Control-Allow-Origin',
+    'dkundel.com'
+  );
   expect(response['headers']).toEqual({
     'Access-Control-Allow-Origin': 'dkundel.com',
   });
+  expect(response2).toBe(response);
 });
 
 test('calls express response correctly', () => {

--- a/packages/twilio-run/src/runtime/internal/response.ts
+++ b/packages/twilio-run/src/runtime/internal/response.ts
@@ -4,44 +4,64 @@ import { getDebugFunction } from '../../utils/logger';
 
 const debug = getDebugFunction('twilio-run:response');
 
+type ResponseOptions = {
+  headers?: Headers;
+  statusCode?: number;
+  body?: object | string;
+};
+
 type HeaderValue = number | string;
 type Headers = {
   [key: string]: HeaderValue;
 };
 
 export class Response implements TwilioResponse {
-  private body: undefined | any;
+  private body: null | any;
   private statusCode: number;
   private headers: Headers;
 
-  constructor() {
-    this.body = undefined;
+  constructor(options?: ResponseOptions) {
+    this.body = null;
     this.statusCode = 200;
     this.headers = {};
+
+    if (options && options.statusCode) {
+      this.statusCode = options.statusCode;
+    }
+    if (options && options.body) {
+      this.body = options.body;
+    }
+    if (options && options.headers) {
+      this.headers = options.headers;
+    }
   }
 
-  setStatusCode(statusCode: number): void {
+  setStatusCode(statusCode: number): Response {
     debug('Setting status code to %d', statusCode);
     this.statusCode = statusCode;
+    return this;
   }
 
-  setBody(body: object | string): void {
+  setBody(body: object | string): Response {
     debug('Setting response body to %o', body);
     this.body = body;
+    return this;
   }
 
-  setHeaders(headersObject: Headers): void {
+  setHeaders(headersObject: Headers): Response {
     debug('Setting headers to: %P', headersObject);
     if (typeof headersObject !== 'object') {
-      return;
+      return this;
     }
     this.headers = headersObject;
+    return this;
   }
 
-  appendHeader(key: string, value: HeaderValue): void {
+  appendHeader(key: string, value: HeaderValue): Response {
     debug('Appending header for %s', key, value);
     this.headers = this.headers || {};
     this.headers[key] = value;
+    return this;
   }
 
   applyToExpressResponse(res: ExpressResponse): void {


### PR DESCRIPTION
I was checking the code behind the `Response` object that Functions uses and noticed some differences, such as:

* set/append functions returning `this` so that you can chain functions
* body is initialized as `null` not `undefined`
* being able to set headers, body and status code in the constructor

I think this brings the serverless toolkit version of the `Response` up to parity in both `twilio-run` and `runtime-handler`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
