### PR TITLE
feat(plugin-assets): can specify --protected flag for asset uploads

### DIFF
--- a/packages/plugin-assets/src/commands/assets/upload.js
+++ b/packages/plugin-assets/src/commands/assets/upload.js
@@ -8,6 +8,7 @@ class UploadCommand extends TwilioClientCommand {
     await super.run();
 
     try {
+      const visibility = this.flags.protected ? 'protected' : 'public';
       const pluginConfig = getPluginConfig(this);
       const assets = await upload({
         apiKey: this.currentProfile.apiKey,
@@ -16,6 +17,7 @@ class UploadCommand extends TwilioClientCommand {
         pluginConfig: pluginConfig,
         file: this.args.file,
         logger: this.logger,
+        visibility,
       });
       this.output(assets, this.flags.properties);
     } catch (error) {
@@ -35,6 +37,10 @@ UploadCommand.args = [
 ];
 
 UploadCommand.flags = {
+  protected: flags.boolean({
+    default: false,
+    description: "Sets the uploaded asset's visibility to 'protected'",
+  }),
   properties: flags.string({
     default: 'sid, path, url, visibility',
     description:

--- a/packages/plugin-assets/src/list.js
+++ b/packages/plugin-assets/src/list.js
@@ -34,9 +34,14 @@ async function list({ pluginConfig, apiKey, apiSecret, accountSid, logger }) {
       try {
         logger.debug(`Fetching build with sid ${environment.build_sid}`);
         const build = await getBuild(environment.build_sid, serviceSid, client);
-        const assets = build.asset_versions.map(assetVersion => {
-          if (assetVersion.visibility === 'public') {
+        const assets = build.asset_versions.map((assetVersion) => {
+          if (
+            assetVersion.visibility === 'public' ||
+            assetVersion.visibility === 'protected'
+          ) {
             assetVersion.url = `https://${environment.domain_name}${assetVersion.path}`;
+          } else {
+            assetVersion.url = '';
           }
           return assetVersion;
         });


### PR DESCRIPTION
With this addition you can now run:

```
twilio assets:upload path/to/file --protected
```

and the uploaded file will require a correct `X-Twilio-Signature` header from your account to return the file. Very useful for audio recordings you want to use on calls, or even just static TwiML.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
