### PR TITLE
chore(serverless-api): update user-agent string for better debugging

### DIFF
--- a/packages/plugin-assets/src/init.js
+++ b/packages/plugin-assets/src/init.js
@@ -9,6 +9,7 @@ const {
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 
 const { couldNotGetEnvironment } = require('./errorMessages');
+const pkgJson = require('../package.json');
 
 async function createServiceAndEnvironment(client, serviceName) {
   const serviceSid = await createService(serviceName, client);
@@ -39,6 +40,7 @@ async function init({
   const client = new TwilioServerlessApiClient({
     username: apiKey,
     password: apiSecret,
+    userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
   });
   const config = await pluginConfig.getConfig();
   if (

--- a/packages/plugin-assets/src/list.js
+++ b/packages/plugin-assets/src/list.js
@@ -5,6 +5,7 @@ const {
 const { getBuild } = require('@twilio-labs/serverless-api/dist/api/builds');
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 const { couldNotGetEnvironment, couldNotGetBuild } = require('./errorMessages');
+const pkgJson = require('../package.json');
 
 async function list({ pluginConfig, apiKey, apiSecret, accountSid, logger }) {
   let environment;
@@ -18,6 +19,7 @@ async function list({ pluginConfig, apiKey, apiSecret, accountSid, logger }) {
     const client = new TwilioServerlessApiClient({
       username: apiKey,
       password: apiSecret,
+      userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
     });
     try {
       logger.debug(

--- a/packages/plugin-assets/src/upload.js
+++ b/packages/plugin-assets/src/upload.js
@@ -31,6 +31,8 @@ const {
   debugFlagMessage,
 } = require('./errorMessages');
 
+const pkgJson = require('../package.json');
+
 function getUtils(spinner, logger) {
   function debug(message) {
     const wasSpinning = spinner.isSpinning;
@@ -331,6 +333,7 @@ async function upload({
     const client = new TwilioServerlessApiClient({
       username: apiKey,
       password: apiSecret,
+      userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
     });
     const environment = await getEnvironmentWithClient(
       client,

--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const camelCase = require('lodash.camelcase');
 const { flags } = require('@oclif/command');
+const pkgJson = require('../package.json');
 
 function convertYargsOptionsToOclifFlags(options) {
   const aliasMap = new Map();
@@ -73,6 +74,10 @@ function normalizeFlags(flags, aliasMap, argv) {
 
 function createExternalCliOptions(flags, twilioClient) {
   const profile = flags.profile;
+  const pluginInfo = {
+    version: pkgJson.version,
+    name: pkgJson.name,
+  };
 
   if (
     (typeof flags.username === 'string' && flags.username.length > 0) ||
@@ -85,6 +90,7 @@ function createExternalCliOptions(flags, twilioClient) {
       profile: undefined,
       logLevel: undefined,
       outputFormat: undefined,
+      pluginInfo,
     };
   }
 
@@ -95,6 +101,7 @@ function createExternalCliOptions(flags, twilioClient) {
     profile,
     logLevel: undefined,
     outputFormat: undefined,
+    pluginInfo,
   };
 }
 

--- a/packages/serverless-api/src/types/client.ts
+++ b/packages/serverless-api/src/types/client.ts
@@ -17,6 +17,10 @@ type BaseClientConfig = {
    * Number of retry attempts the client will make on a failure
    */
   retryLimit?: number;
+  /**
+   * Additional information to pass to the User-Agent. !!!Should not contain sensitive information
+   */
+  userAgentExtensions?: string[];
 };
 
 export type AccountSidConfig = BaseClientConfig & {

--- a/packages/serverless-api/src/utils/__tests__/package-info.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/package-info.test.ts
@@ -1,0 +1,6 @@
+import pkgJson from '../package-info';
+
+test('imports package.json information', () => {
+  const pkgJsonSource = require('../../../package.json');
+  expect(pkgJson).toEqual(pkgJsonSource);
+});

--- a/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
@@ -1,0 +1,39 @@
+import {
+  getUserAgent,
+  _addCustomUserAgentExtension,
+  _resetUserAgentExtensions,
+} from '../user-agent';
+
+jest.mock('../package-info', () => {
+  return {
+    name: '@twilio-labs/serverless-api-test',
+    version: '1.0.0-test',
+  };
+});
+
+jest.mock('os', () => {
+  return {
+    platform: () => 'darwin',
+    arch: () => 'x64',
+  };
+});
+
+describe('getUserAgent', () => {
+  test('should return the right base information', () => {
+    expect(getUserAgent()).toEqual(
+      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64)'
+    );
+  });
+
+  test('adds extensions and correctly resets extensions', () => {
+    _addCustomUserAgentExtension('twilio-run/2.0.0-test');
+    _addCustomUserAgentExtension('@twilio-labs/plugin-serverless/1.1.0-test');
+    expect(getUserAgent()).toEqual(
+      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) twilio-run/2.0.0-test @twilio-labs/plugin-serverless/1.1.0-test'
+    );
+    _resetUserAgentExtensions();
+    expect(getUserAgent()).toEqual(
+      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64)'
+    );
+  });
+});

--- a/packages/serverless-api/src/utils/package-info.ts
+++ b/packages/serverless-api/src/utils/package-info.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+import { PackageJson } from 'type-fest';
+
+const pkgJson: PackageJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8')
+);
+
+export default pkgJson;

--- a/packages/serverless-api/src/utils/user-agent.ts
+++ b/packages/serverless-api/src/utils/user-agent.ts
@@ -1,0 +1,24 @@
+import os from 'os';
+import pkgJson from './package-info';
+
+let extensions: string[] = [];
+
+export function getUserAgent() {
+  const name = pkgJson.name || '@twilio-labs/serverless-api';
+  const version = pkgJson.version || '0.0.0';
+  const osName = os.platform() || 'unknown';
+  const osArch = os.arch() || 'unknown';
+  const extensionString =
+    extensions.length > 0 ? ' ' + extensions.join(' ') : '';
+  return `${name}/${version} (${osName} ${osArch})${extensionString}`;
+}
+
+export function _resetUserAgentExtensions() {
+  extensions = [];
+}
+
+export function _addCustomUserAgentExtension(extensionName: string) {
+  extensions = [...extensions, extensionName];
+}
+
+export default getUserAgent;

--- a/packages/serverless-twilio-runtime/util/util.js
+++ b/packages/serverless-twilio-runtime/util/util.js
@@ -2,11 +2,12 @@
 
 const {
   TwilioServerlessApiClient,
-  utils
+  utils,
 } = require('@twilio-labs/serverless-api');
 const path = require('path');
 const { readFile } = utils;
 const { logMessage } = require('./log');
+const pkgJson = require('../package.json');
 
 /**
  * Initialize the Twilio client and attach serverless logging to it
@@ -19,10 +20,13 @@ function getTwilioClient(serverless) {
 
   const client = new TwilioServerlessApiClient({
     accountSid,
-    authToken
+    authToken,
+    userAgentExtensions: [
+      `@twilio-labs/serverless-twilio-runtime/${pkgJson.version}`,
+    ],
   });
 
-  client.on('status-update', evt => {
+  client.on('status-update', (evt) => {
     logMessage(serverless, evt.message);
   });
 
@@ -40,13 +44,13 @@ async function getTwilioDeployConfig(serverless, options = {}) {
   const config = {
     env: serverless.service.provider.environmentVars || {},
     pkgJson: {
-      dependencies: serverless.service.provider.dependencies
+      dependencies: serverless.service.provider.dependencies,
     },
     serviceName: serverless.service.service,
     functionsEnv: serverless.service.provider.environment || 'dev',
     assets: [],
     functions: [],
-    overrideExistingService: true
+    overrideExistingService: true,
   };
 
   if (serverless.service.functions) {
@@ -134,11 +138,11 @@ async function getEnvironment(
 ) {
   const { environments } = await twilioServerlessClient.list({
     types: ['environments'],
-    serviceName
+    serviceName,
   });
 
   const environment = environments.find(
-    env => env.domain_suffix === environmentName
+    (env) => env.domain_suffix === environmentName
   );
 
   if (!environment) {
@@ -154,5 +158,5 @@ module.exports = {
   getEnvironment,
   getTwilioClient,
   getTwilioDeployConfig,
-  readFile
+  readFile,
 };

--- a/packages/twilio-run/src/commands/shared.ts
+++ b/packages/twilio-run/src/commands/shared.ts
@@ -6,4 +6,8 @@ export type ExternalCliOptions = {
   project?: string;
   logLevel?: string;
   outputFormat?: string;
+  pluginInfo?: {
+    name: string;
+    version: string;
+  };
 };

--- a/packages/twilio-run/src/config/deploy.ts
+++ b/packages/twilio-run/src/config/deploy.ts
@@ -18,6 +18,7 @@ import {
   readPackageJsonContent,
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type DeployLocalProjectConfig = ApiDeployLocalProjectConfig & {
   username: string;
@@ -131,5 +132,6 @@ export async function getConfigFromFlags(
     region,
     edge,
     runtime,
+    userAgentExtensions: getUserAgentExtensions('deploy', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/list.ts
+++ b/packages/twilio-run/src/config/list.ts
@@ -18,6 +18,7 @@ import {
   readLocalEnvFile,
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type ListConfig = ApiListConfig & {
   username: string;
@@ -99,11 +100,12 @@ export async function getConfigFromFlags(
     serviceName,
     environment: flags.environment,
     properties: flags.properties
-      ? flags.properties.split(',').map(x => x.trim())
+      ? flags.properties.split(',').map((x) => x.trim())
       : undefined,
     extendedOutput: flags.extendedOutput,
     types,
     region,
     edge,
+    userAgentExtensions: getUserAgentExtensions('list', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/logs.ts
+++ b/packages/twilio-run/src/config/logs.ts
@@ -16,6 +16,7 @@ import { getFunctionServiceSid } from '../serverless-api/utils';
 import { readSpecializedConfig } from './global';
 import { getCredentialsFromFlags, readLocalEnvFile } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type LogsConfig = ClientConfig &
   ApiLogsConfig & {
@@ -104,5 +105,6 @@ export async function getConfigFromFlags(
     region,
     edge,
     logCacheSize: flags.logCacheSize,
+    userAgentExtensions: getUserAgentExtensions('logs', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/promote.ts
+++ b/packages/twilio-run/src/config/promote.ts
@@ -17,6 +17,7 @@ import {
   readLocalEnvFile,
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type PromoteConfig = ApiActivateConfig & {
   cwd: string;
@@ -99,5 +100,6 @@ export async function getConfigFromFlags(
     region,
     edge,
     env,
+    userAgentExtensions: getUserAgentExtensions('promote', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/utils/userAgentExtensions.ts
+++ b/packages/twilio-run/src/config/utils/userAgentExtensions.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { ExternalCliOptions } from '../../commands/shared';
+
+const pkgJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8')
+);
+
+export function getUserAgentExtensions(
+  command: string,
+  externalCliOptions?: ExternalCliOptions
+) {
+  const extensions = [`twilio-run/${pkgJson.version || '0.0.0'}`];
+
+  if (typeof externalCliOptions?.pluginInfo !== 'undefined') {
+    const { name, version } = externalCliOptions.pluginInfo;
+    extensions.push(`${name}/${version}`);
+  }
+
+  extensions.push(`twilio-run:${command}`);
+
+  return extensions;
+}


### PR DESCRIPTION
<!-- Describe your Pull Request -->
This PR standardizes the format of our User-Agent string in `@twilio-labs/serverless-api` and provide the ability to pass additional information from upstream packages to be included. It follows the agreed pattern of:

```
<core-api-lib>/<core-api-lib-version> (<os-name> <os-arch>) <extensions>
```

Where `<extensions>` are being added space separated following:

```
<library>/<library-version>
```

or

```
<tag>
```

In this case the `TwilioServerlessApiClient` offers to pass in `userAgentExtensions` as an array to specify upstream libraries who use it to add their library name and version.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
