### PR TITLE
refactor(serverless-api): update user-agent string for better debugging

### DIFF
--- a/packages/plugin-assets/src/client.js
+++ b/packages/plugin-assets/src/client.js
@@ -1,0 +1,12 @@
+const pkgJson = require('../package.json');
+const { TwilioServerlessApiClient } = require('@twilio-labs/serverless-api');
+
+function getTwilioClient(apiKey, apiSecret) {
+  return new TwilioServerlessApiClient({
+    username: apiKey,
+    password: apiSecret,
+    userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
+  });
+}
+
+module.exports = { getTwilioClient: getTwilioClient };

--- a/packages/plugin-assets/src/init.js
+++ b/packages/plugin-assets/src/init.js
@@ -9,7 +9,7 @@ const {
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 
 const { couldNotGetEnvironment } = require('./errorMessages');
-const pkgJson = require('../package.json');
+const { getTwilioClient } = require('./client');
 
 async function createServiceAndEnvironment(client, serviceName) {
   const serviceSid = await createService(serviceName, client);
@@ -37,11 +37,7 @@ async function init({
   serviceName,
 }) {
   logger.debug('Loading config');
-  const client = new TwilioServerlessApiClient({
-    username: apiKey,
-    password: apiSecret,
-    userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
-  });
+  const client = getTwilioClient(apiKey, apiSecret);
   const config = await pluginConfig.getConfig();
   if (
     config[accountSid] &&

--- a/packages/plugin-assets/src/init.js
+++ b/packages/plugin-assets/src/init.js
@@ -1,4 +1,3 @@
-const { TwilioServerlessApiClient } = require('@twilio-labs/serverless-api');
 const {
   createService,
 } = require('@twilio-labs/serverless-api/dist/api/services');

--- a/packages/plugin-assets/src/init.js
+++ b/packages/plugin-assets/src/init.js
@@ -9,6 +9,7 @@ const {
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 
 const { couldNotGetEnvironment } = require('./errorMessages');
+const pkgJson = require('../package.json');
 
 async function createServiceAndEnvironment(client, serviceName) {
   const serviceSid = await createService(serviceName, client);
@@ -39,6 +40,7 @@ async function init({
   const client = new TwilioServerlessApiClient({
     username: apiKey,
     password: apiSecret,
+    userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
   });
   const config = await pluginConfig.getConfig();
   if (

--- a/packages/plugin-assets/src/list.js
+++ b/packages/plugin-assets/src/list.js
@@ -1,4 +1,3 @@
-const { TwilioServerlessApiClient } = require('@twilio-labs/serverless-api');
 const {
   getEnvironment,
 } = require('@twilio-labs/serverless-api/dist/api/environments');

--- a/packages/plugin-assets/src/list.js
+++ b/packages/plugin-assets/src/list.js
@@ -5,7 +5,7 @@ const {
 const { getBuild } = require('@twilio-labs/serverless-api/dist/api/builds');
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 const { couldNotGetEnvironment, couldNotGetBuild } = require('./errorMessages');
-const pkgJson = require('../package.json');
+const { getTwilioClient } = require('./client');
 
 async function list({ pluginConfig, apiKey, apiSecret, accountSid, logger }) {
   let environment;
@@ -16,11 +16,7 @@ async function list({ pluginConfig, apiKey, apiSecret, accountSid, logger }) {
     config[accountSid].environmentSid
   ) {
     const { serviceSid, environmentSid } = config[accountSid];
-    const client = new TwilioServerlessApiClient({
-      username: apiKey,
-      password: apiSecret,
-      userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
-    });
+    const client = getTwilioClient(apiKey, apiSecret);
     try {
       logger.debug(
         `Fetching environment with sid ${environmentSid} from service with sid ${serviceSid}`

--- a/packages/plugin-assets/src/list.js
+++ b/packages/plugin-assets/src/list.js
@@ -5,6 +5,7 @@ const {
 const { getBuild } = require('@twilio-labs/serverless-api/dist/api/builds');
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 const { couldNotGetEnvironment, couldNotGetBuild } = require('./errorMessages');
+const pkgJson = require('../package.json');
 
 async function list({ pluginConfig, apiKey, apiSecret, accountSid, logger }) {
   let environment;
@@ -18,6 +19,7 @@ async function list({ pluginConfig, apiKey, apiSecret, accountSid, logger }) {
     const client = new TwilioServerlessApiClient({
       username: apiKey,
       password: apiSecret,
+      userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
     });
     try {
       logger.debug(

--- a/packages/plugin-assets/src/upload.js
+++ b/packages/plugin-assets/src/upload.js
@@ -31,6 +31,8 @@ const {
   debugFlagMessage,
 } = require('./errorMessages');
 
+const pkgJson = require('../package.json');
+
 function getUtils(spinner, logger) {
   function debug(message) {
     const wasSpinning = spinner.isSpinning;
@@ -331,6 +333,7 @@ async function upload({
     const client = new TwilioServerlessApiClient({
       username: apiKey,
       password: apiSecret,
+      userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
     });
     const environment = await getEnvironmentWithClient(
       client,

--- a/packages/plugin-assets/src/upload.js
+++ b/packages/plugin-assets/src/upload.js
@@ -31,7 +31,7 @@ const {
   debugFlagMessage,
 } = require('./errorMessages');
 
-const pkgJson = require('../package.json');
+const { getTwilioClient } = require('./client');
 
 function getUtils(spinner, logger) {
   function debug(message) {
@@ -330,11 +330,7 @@ async function upload({
     config[accountSid].environmentSid
   ) {
     const { serviceSid, environmentSid } = config[accountSid];
-    const client = new TwilioServerlessApiClient({
-      username: apiKey,
-      password: apiSecret,
-      userAgentExtensions: [`@twilio-labs/plugin-assets/${pkgJson.version}`],
-    });
+    const client = getTwilioClient(apiKey, apiSecret);
     const environment = await getEnvironmentWithClient(
       client,
       environmentSid,

--- a/packages/plugin-assets/src/upload.js
+++ b/packages/plugin-assets/src/upload.js
@@ -1,6 +1,5 @@
 const ora = require('ora');
 const inquirer = require('inquirer');
-const { TwilioServerlessApiClient } = require('@twilio-labs/serverless-api');
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
 const {
   getEnvironment,

--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const camelCase = require('lodash.camelcase');
 const { flags } = require('@oclif/command');
+const pkgJson = require('../package.json');
 
 function convertYargsOptionsToOclifFlags(options) {
   const aliasMap = new Map();
@@ -73,6 +74,10 @@ function normalizeFlags(flags, aliasMap, argv) {
 
 function createExternalCliOptions(flags, twilioClient) {
   const profile = flags.profile;
+  const pluginInfo = {
+    version: pkgJson.version,
+    name: pkgJson.name,
+  };
 
   if (
     (typeof flags.username === 'string' && flags.username.length > 0) ||
@@ -85,6 +90,7 @@ function createExternalCliOptions(flags, twilioClient) {
       profile: undefined,
       logLevel: undefined,
       outputFormat: undefined,
+      pluginInfo,
     };
   }
 
@@ -95,6 +101,7 @@ function createExternalCliOptions(flags, twilioClient) {
     profile,
     logLevel: undefined,
     outputFormat: undefined,
+    pluginInfo,
   };
 }
 

--- a/packages/serverless-api/__mocks__/os.ts
+++ b/packages/serverless-api/__mocks__/os.ts
@@ -1,0 +1,4 @@
+export default {
+  platform: () => 'darwin',
+  arch: () => 'x64',
+};

--- a/packages/serverless-api/src/__fixtures__/base-fixtures.ts
+++ b/packages/serverless-api/src/__fixtures__/base-fixtures.ts
@@ -1,15 +1,11 @@
-import {
-  ClientConfig,
-  AccountSidConfig,
-  UsernameConfig,
-} from '../types/client';
+import { AccountSidConfig, UsernameConfig } from '../types/client';
 
 export const DEFAULT_TEST_CLIENT_CONFIG: AccountSidConfig = {
   accountSid: 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-  authToken: '<SECRET>',
+  authToken: 'SECRET',
 };
 
 export const DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD: UsernameConfig = {
   username: 'ACyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy',
-  password: '<PASSWORD>',
+  password: 'PASSWORD',
 };

--- a/packages/serverless-api/src/__tests__/integration.test.ts
+++ b/packages/serverless-api/src/__tests__/integration.test.ts
@@ -1,0 +1,161 @@
+import nock from 'nock';
+import { UsernameConfig } from '../../dist';
+import { getPaginatedResource } from '../api/utils/pagination';
+import TwilioServerlessApiClient from '../client';
+import { DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD } from '../__fixtures__/base-fixtures';
+
+jest.mock('os');
+jest.mock('../utils/package-info');
+
+const DEFAULT_USER_AGENT = `@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) node/${process.version}`;
+const DEFAULT_CREDENTIALS = {
+  user: DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD.username,
+  pass: DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD.password,
+};
+
+const DEFAULT_HEADERS = {
+  'user-agent': DEFAULT_USER_AGENT,
+  accept: 'application/json',
+  'accept-encoding': 'gzip, deflate, br',
+};
+
+describe('API integration tests', () => {
+  let apiNock: nock.Scope,
+    config: UsernameConfig,
+    apiClient: TwilioServerlessApiClient;
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  beforeEach(() => {
+    apiNock = nock('https://serverless.twilio.com', {
+      reqheaders: DEFAULT_HEADERS,
+    });
+    config = DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD;
+    apiClient = new TwilioServerlessApiClient(config);
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
+  describe('basic requests', () => {
+    test('handles get requests', async () => {
+      const scope = apiNock
+        .get('/v1/Services')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, { services: [] });
+
+      await apiClient.request('get', 'Services');
+      scope.done();
+    });
+
+    test('handles post request', async () => {
+      const scope = apiNock
+        .post('/v1/Services', 'UniqueName=test-app')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, {});
+      await apiClient.request('post', 'Services', {
+        form: {
+          UniqueName: 'test-app',
+        },
+      });
+
+      scope.done();
+    });
+
+    test('handles delete request', async () => {
+      const scope = apiNock
+        .delete('/v1/Services/ZS11111111111111111111111111111111')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, {});
+
+      await apiClient.request(
+        'delete',
+        'Services/ZS11111111111111111111111111111111'
+      );
+      scope.done();
+    });
+
+    test('passes user-agent extensions', async () => {
+      apiNock = nock('https://serverless.twilio.com', {
+        reqheaders: {
+          ...DEFAULT_HEADERS,
+          'user-agent':
+            DEFAULT_USER_AGENT +
+            ' twilio-run/1.0.0-test plugin-serverless/1.2.0-test',
+        },
+      });
+      config = DEFAULT_TEST_CLIENT_CONFIG_USERNAME_PASSWORD;
+      apiClient = new TwilioServerlessApiClient({
+        ...config,
+        userAgentExtensions: [
+          'twilio-run/1.0.0-test',
+          'plugin-serverless/1.2.0-test',
+        ],
+      });
+
+      const scope = apiNock
+        .get('/v1/Services')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, { services: [] });
+
+      await apiClient.request('get', 'Services');
+      scope.done();
+    });
+  });
+
+  describe('paginated requests', () => {
+    const BASE_PAGE_URL =
+      'https://serverless.twilio.com/v1/Services?PageSize=50&Page=';
+    const BASE_PAGE_INFO = {
+      first_page_url: BASE_PAGE_URL + '0',
+      key: 'services',
+      next_page_url: null,
+      page_size: 50,
+      previous_page_url: null,
+      url: BASE_PAGE_URL,
+    };
+    const EXAMPLE_SERVICES = [
+      { sid: 'ZS11111111111111111111111111111111' },
+      { sid: 'ZS11111111111111111111111111111112' },
+      { sid: 'ZS11111111111111111111111111111113' },
+    ];
+
+    test('handles single page', async () => {
+      apiNock
+        .get('/v1/Services')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, { services: [EXAMPLE_SERVICES[0]], meta: BASE_PAGE_INFO });
+
+      const resp = await getPaginatedResource(apiClient, 'Services');
+      expect(resp.length).toEqual(1);
+    });
+
+    test('handles multi page requests', async () => {
+      apiNock
+        .get('/v1/Services')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, {
+          services: [EXAMPLE_SERVICES[0]],
+          meta: { ...BASE_PAGE_INFO, next_page_url: BASE_PAGE_URL + '1' },
+        })
+        .get('/v1/Services?PageSize=50&Page=1')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, {
+          services: [EXAMPLE_SERVICES[1]],
+          meta: {
+            ...BASE_PAGE_INFO,
+            previous_page_url: BASE_PAGE_URL + '0',
+            next_page_url: BASE_PAGE_URL + '2',
+          },
+        })
+        .get('/v1/Services?PageSize=50&Page=2')
+        .basicAuth(DEFAULT_CREDENTIALS)
+        .reply(200, { services: [EXAMPLE_SERVICES[2]], meta: BASE_PAGE_INFO });
+
+      const resp = await getPaginatedResource(apiClient, 'Services');
+      expect(resp.length).toEqual(3);
+    });
+  });
+});

--- a/packages/serverless-api/src/types/client.ts
+++ b/packages/serverless-api/src/types/client.ts
@@ -17,6 +17,10 @@ type BaseClientConfig = {
    * Number of retry attempts the client will make on a failure
    */
   retryLimit?: number;
+  /**
+   * Additional information to pass to the User-Agent. !!!Should not contain sensitive information
+   */
+  userAgentExtensions?: string[];
 };
 
 export type AccountSidConfig = BaseClientConfig & {

--- a/packages/serverless-api/src/utils/__mocks__/package-info.ts
+++ b/packages/serverless-api/src/utils/__mocks__/package-info.ts
@@ -1,0 +1,4 @@
+export default {
+  name: '@twilio-labs/serverless-api-test',
+  version: '1.0.0-test',
+};

--- a/packages/serverless-api/src/utils/__tests__/package-info.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/package-info.test.ts
@@ -1,0 +1,6 @@
+import pkgJson from '../package-info';
+
+test('imports package.json information', () => {
+  const pkgJsonSource = require('../../../package.json');
+  expect(pkgJson).toEqual(pkgJsonSource);
+});

--- a/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
@@ -14,10 +14,12 @@ jest.mock('os', () => {
   };
 });
 
+const nodeVersion = process.version;
+
 describe('getUserAgent', () => {
   test('should return the right base information', () => {
     expect(getUserAgent()).toEqual(
-      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64)'
+      `@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) node/${nodeVersion}`
     );
   });
 
@@ -28,10 +30,10 @@ describe('getUserAgent', () => {
         '@twilio-labs/plugin-serverless/1.1.0-test',
       ])
     ).toEqual(
-      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) twilio-run/2.0.0-test @twilio-labs/plugin-serverless/1.1.0-test'
+      `@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) node/${nodeVersion} twilio-run/2.0.0-test @twilio-labs/plugin-serverless/1.1.0-test`
     );
     expect(getUserAgent()).toEqual(
-      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64)'
+      `@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) node/${nodeVersion}`
     );
   });
 });

--- a/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
@@ -1,0 +1,39 @@
+import {
+  getUserAgent,
+  _addCustomUserAgentExtension,
+  _resetUserAgentExtensions,
+} from '../user-agent';
+
+jest.mock('../package-info', () => {
+  return {
+    name: '@twilio-labs/serverless-api-test',
+    version: '1.0.0-test',
+  };
+});
+
+jest.mock('os', () => {
+  return {
+    platform: () => 'darwin',
+    arch: () => 'x64',
+  };
+});
+
+describe('getUserAgent', () => {
+  test('should return the right base information', () => {
+    expect(getUserAgent()).toEqual(
+      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64)'
+    );
+  });
+
+  test('adds extensions and correctly resets extensions', () => {
+    _addCustomUserAgentExtension('twilio-run/2.0.0-test');
+    _addCustomUserAgentExtension('@twilio-labs/plugin-serverless/1.1.0-test');
+    expect(getUserAgent()).toEqual(
+      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) twilio-run/2.0.0-test @twilio-labs/plugin-serverless/1.1.0-test'
+    );
+    _resetUserAgentExtensions();
+    expect(getUserAgent()).toEqual(
+      '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64)'
+    );
+  });
+});

--- a/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
@@ -1,8 +1,4 @@
-import {
-  getUserAgent,
-  _addCustomUserAgentExtension,
-  _resetUserAgentExtensions,
-} from '../user-agent';
+import { getUserAgent } from '../user-agent';
 
 jest.mock('../package-info', () => {
   return {
@@ -26,12 +22,14 @@ describe('getUserAgent', () => {
   });
 
   test('adds extensions and correctly resets extensions', () => {
-    _addCustomUserAgentExtension('twilio-run/2.0.0-test');
-    _addCustomUserAgentExtension('@twilio-labs/plugin-serverless/1.1.0-test');
-    expect(getUserAgent()).toEqual(
+    expect(
+      getUserAgent([
+        'twilio-run/2.0.0-test',
+        '@twilio-labs/plugin-serverless/1.1.0-test',
+      ])
+    ).toEqual(
       '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64) twilio-run/2.0.0-test @twilio-labs/plugin-serverless/1.1.0-test'
     );
-    _resetUserAgentExtensions();
     expect(getUserAgent()).toEqual(
       '@twilio-labs/serverless-api-test/1.0.0-test (darwin x64)'
     );

--- a/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
+++ b/packages/serverless-api/src/utils/__tests__/user-agent.test.ts
@@ -1,18 +1,8 @@
 import { getUserAgent } from '../user-agent';
 
-jest.mock('../package-info', () => {
-  return {
-    name: '@twilio-labs/serverless-api-test',
-    version: '1.0.0-test',
-  };
-});
+jest.mock('../package-info');
 
-jest.mock('os', () => {
-  return {
-    platform: () => 'darwin',
-    arch: () => 'x64',
-  };
-});
+jest.mock('os');
 
 const nodeVersion = process.version;
 

--- a/packages/serverless-api/src/utils/package-info.ts
+++ b/packages/serverless-api/src/utils/package-info.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+import { PackageJson } from 'type-fest';
+
+const pkgJson: PackageJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8')
+);
+
+export default pkgJson;

--- a/packages/serverless-api/src/utils/user-agent.ts
+++ b/packages/serverless-api/src/utils/user-agent.ts
@@ -1,0 +1,24 @@
+import os from 'os';
+import pkgJson from './package-info';
+
+let extensions: string[] = [];
+
+export function getUserAgent() {
+  const name = pkgJson.name || '@twilio-labs/serverless-api';
+  const version = pkgJson.version || '0.0.0';
+  const osName = os.platform() || 'unknown';
+  const osArch = os.arch() || 'unknown';
+  const extensionString =
+    extensions.length > 0 ? ' ' + extensions.join(' ') : '';
+  return `${name}/${version} (${osName} ${osArch})${extensionString}`;
+}
+
+export function _resetUserAgentExtensions() {
+  extensions = [];
+}
+
+export function _addCustomUserAgentExtension(extensionName: string) {
+  extensions = [...extensions, extensionName];
+}
+
+export default getUserAgent;

--- a/packages/serverless-api/src/utils/user-agent.ts
+++ b/packages/serverless-api/src/utils/user-agent.ts
@@ -9,7 +9,7 @@ export function getUserAgent(extensions: string[] = []) {
   const nodeVersion = process.version || '0.0.0';
   const extensionString =
     extensions.length > 0 ? ' ' + extensions.join(' ') : '';
-  return `${name}/${version} (${osName} ${osArch}) node/${nodeVersion} ${extensionString}`;
+  return `${name}/${version} (${osName} ${osArch}) node/${nodeVersion}${extensionString}`;
 }
 
 export default getUserAgent;

--- a/packages/serverless-api/src/utils/user-agent.ts
+++ b/packages/serverless-api/src/utils/user-agent.ts
@@ -1,24 +1,15 @@
 import os from 'os';
 import pkgJson from './package-info';
 
-let extensions: string[] = [];
-
-export function getUserAgent() {
+export function getUserAgent(extensions: string[] = []) {
   const name = pkgJson.name || '@twilio-labs/serverless-api';
   const version = pkgJson.version || '0.0.0';
   const osName = os.platform() || 'unknown';
   const osArch = os.arch() || 'unknown';
+  const nodeVersion = process.version || '0.0.0';
   const extensionString =
     extensions.length > 0 ? ' ' + extensions.join(' ') : '';
-  return `${name}/${version} (${osName} ${osArch})${extensionString}`;
-}
-
-export function _resetUserAgentExtensions() {
-  extensions = [];
-}
-
-export function _addCustomUserAgentExtension(extensionName: string) {
-  extensions = [...extensions, extensionName];
+  return `${name}/${version} (${osName} ${osArch}) node/${nodeVersion} ${extensionString}`;
 }
 
 export default getUserAgent;

--- a/packages/serverless-twilio-runtime/util/util.js
+++ b/packages/serverless-twilio-runtime/util/util.js
@@ -2,11 +2,12 @@
 
 const {
   TwilioServerlessApiClient,
-  utils
+  utils,
 } = require('@twilio-labs/serverless-api');
 const path = require('path');
 const { readFile } = utils;
 const { logMessage } = require('./log');
+const pkgJson = require('../package.json');
 
 /**
  * Initialize the Twilio client and attach serverless logging to it
@@ -19,10 +20,13 @@ function getTwilioClient(serverless) {
 
   const client = new TwilioServerlessApiClient({
     accountSid,
-    authToken
+    authToken,
+    userAgentExtensions: [
+      `@twilio-labs/serverless-twilio-runtime/${pkgJson.version}`,
+    ],
   });
 
-  client.on('status-update', evt => {
+  client.on('status-update', (evt) => {
     logMessage(serverless, evt.message);
   });
 
@@ -40,13 +44,13 @@ async function getTwilioDeployConfig(serverless, options = {}) {
   const config = {
     env: serverless.service.provider.environmentVars || {},
     pkgJson: {
-      dependencies: serverless.service.provider.dependencies
+      dependencies: serverless.service.provider.dependencies,
     },
     serviceName: serverless.service.service,
     functionsEnv: serverless.service.provider.environment || 'dev',
     assets: [],
     functions: [],
-    overrideExistingService: true
+    overrideExistingService: true,
   };
 
   if (serverless.service.functions) {
@@ -134,11 +138,11 @@ async function getEnvironment(
 ) {
   const { environments } = await twilioServerlessClient.list({
     types: ['environments'],
-    serviceName
+    serviceName,
   });
 
   const environment = environments.find(
-    env => env.domain_suffix === environmentName
+    (env) => env.domain_suffix === environmentName
   );
 
   if (!environment) {
@@ -154,5 +158,5 @@ module.exports = {
   getEnvironment,
   getTwilioClient,
   getTwilioDeployConfig,
-  readFile
+  readFile,
 };

--- a/packages/twilio-run/src/commands/shared.ts
+++ b/packages/twilio-run/src/commands/shared.ts
@@ -6,4 +6,8 @@ export type ExternalCliOptions = {
   project?: string;
   logLevel?: string;
   outputFormat?: string;
+  pluginInfo?: {
+    name: string;
+    version: string;
+  };
 };

--- a/packages/twilio-run/src/config/deploy.ts
+++ b/packages/twilio-run/src/config/deploy.ts
@@ -18,6 +18,7 @@ import {
   readPackageJsonContent,
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type DeployLocalProjectConfig = ApiDeployLocalProjectConfig & {
   username: string;
@@ -131,5 +132,6 @@ export async function getConfigFromFlags(
     region,
     edge,
     runtime,
+    userAgentExtensions: getUserAgentExtensions('deploy', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/list.ts
+++ b/packages/twilio-run/src/config/list.ts
@@ -18,6 +18,7 @@ import {
   readLocalEnvFile,
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type ListConfig = ApiListConfig & {
   username: string;
@@ -99,11 +100,12 @@ export async function getConfigFromFlags(
     serviceName,
     environment: flags.environment,
     properties: flags.properties
-      ? flags.properties.split(',').map(x => x.trim())
+      ? flags.properties.split(',').map((x) => x.trim())
       : undefined,
     extendedOutput: flags.extendedOutput,
     types,
     region,
     edge,
+    userAgentExtensions: getUserAgentExtensions('list', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/logs.ts
+++ b/packages/twilio-run/src/config/logs.ts
@@ -16,6 +16,7 @@ import { getFunctionServiceSid } from '../serverless-api/utils';
 import { readSpecializedConfig } from './global';
 import { getCredentialsFromFlags, readLocalEnvFile } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type LogsConfig = ClientConfig &
   ApiLogsConfig & {
@@ -104,5 +105,6 @@ export async function getConfigFromFlags(
     region,
     edge,
     logCacheSize: flags.logCacheSize,
+    userAgentExtensions: getUserAgentExtensions('logs', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/promote.ts
+++ b/packages/twilio-run/src/config/promote.ts
@@ -17,6 +17,7 @@ import {
   readLocalEnvFile,
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { getUserAgentExtensions } from './utils/userAgentExtensions';
 
 export type PromoteConfig = ApiActivateConfig & {
   cwd: string;
@@ -99,5 +100,6 @@ export async function getConfigFromFlags(
     region,
     edge,
     env,
+    userAgentExtensions: getUserAgentExtensions('promote', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/utils/userAgentExtensions.ts
+++ b/packages/twilio-run/src/config/utils/userAgentExtensions.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+import { ExternalCliOptions } from '../../commands/shared';
+
+const pkgJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../package.json'), 'utf8')
+);
+
+export function getUserAgentExtensions(
+  command: string,
+  externalCliOptions?: ExternalCliOptions
+) {
+  const extensions = [`twilio-run/${pkgJson.version || '0.0.0'}`];
+
+  if (typeof externalCliOptions?.pluginInfo !== 'undefined') {
+    const { name, version } = externalCliOptions.pluginInfo;
+    extensions.push(`${name}/${version}`);
+  }
+
+  extensions.push(`twilio-run:${command}`);
+
+  return extensions;
+}


### PR DESCRIPTION
<!-- Describe your Pull Request -->
This PR standardizes the format of our User-Agent string in `@twilio-labs/serverless-api` and provide the ability to pass additional information from upstream packages to be included. It follows the agreed pattern of:

```
<core-api-lib>/<core-api-lib-version> (<os-name> <os-arch>) <extensions>
```

Where `<extensions>` are being added space separated following:

```
<library>/<library-version>
```

or

```
<tag>
```

In this case the `TwilioServerlessApiClient` offers to pass in `userAgentExtensions` as an array to specify upstream libraries who use it to add their library name and version.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
