### PR TITLE
feat(runtime-types): add cookie/header support for types 

### DIFF
--- a/packages/serverless-runtime-types/example/functions/demo.js
+++ b/packages/serverless-runtime-types/example/functions/demo.js
@@ -2,11 +2,12 @@
 
 /**
  * @param {import('@twilio-labs/serverless-runtime-types').Context} context
- * @param {{}} event
+ * @param {import('@twilio-labs/serverless-runtime-types').ServerlessEventObject<{}, {}, { token: string }>} event
  * @param {import('@twilio-labs/serverless-runtime-types').ServerlessCallback} callback
  */
-exports.handler = function(context, event, callback) {
+exports.handler = function (context, event, callback) {
   let twiml = new Twilio.twiml.MessagingResponse();
+  console.log(event.cookies.token);
   twiml.message('Hello World');
   callback(null, twiml);
 };

--- a/packages/serverless-runtime-types/types.d.ts
+++ b/packages/serverless-runtime-types/types.d.ts
@@ -22,10 +22,12 @@ export type AssetResourceMap = {
 };
 
 export interface TwilioResponse {
-  setStatusCode(code: number): void;
-  setBody(body: string | object): void;
-  appendHeader(key: string, value: string): void;
-  setHeaders(headers: { [key: string]: string }): void;
+  setStatusCode(code: number): TwilioResponse;
+  setBody(body: string | object): TwilioResponse;
+  appendHeader(key: string, value: string): TwilioResponse;
+  setHeaders(headers: { [key: string]: string }): TwilioResponse;
+  setCookie(key: string, value: string, attributes?: string[]): TwilioResponse;
+  removeCookie(key: string): TwilioResponse;
 }
 
 export type RuntimeSyncClientOptions = TwilioClientOptions & {
@@ -53,9 +55,20 @@ export type ServerlessCallback = (
   payload?: object | string | number | boolean
 ) => void;
 
+export type ServerlessEventObject<
+  RequestBodyAndQuery = {},
+  Headers = {},
+  Cookies = {}
+> = {
+  request: {
+    cookies: Cookies;
+    headers: Headers;
+  };
+} & RequestBodyAndQuery;
+
 export type ServerlessFunctionSignature<
   T extends EnvironmentVariables = {},
-  U extends {} = {}
+  U extends ServerlessEventObject = { request: { cookies: {}; headers: {} } }
 > = (
   context: Context<T>,
   event: U,


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This change adds updated TypeScript definitions for `@twilio/runtime-handler@1.2.0`. Realistically long-term we should probably merge the two packages so that versioning is correctly handled. In the meantime I'm going with this solution.

This PR is dependent on #296 to be merged for successful compilation.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
