### PR TITLE
chore: upgrades husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run pre-commit

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "contrib:add": "all-contributors add",
     "contrib:generate": "all-contributors generate",
     "lint-staged": "lint-staged",
-    "docs": "lerna run docs"
+    "docs": "lerna run docs",
+    "prepare": "husky install",
+    "pre-commit": "run-s lint-staged test"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
@@ -24,7 +26,7 @@
     "commitizen": "^3.1.1",
     "conventional-changelog-cli": "^2.1.0",
     "cz-conventional-changelog": "^2.1.0",
-    "husky": "^3.0.0",
+    "husky": "^7.0.0",
     "jest": "^26.2.2",
     "jest-express": "^1.10.1",
     "lerna": "^3.22.1",
@@ -34,12 +36,6 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.0.0",
     "typescript": "^3.9.7"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "run-s lint-staged test",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
I constantly get caught by commitlint, mostly for using 73 characters these days, though it used to be for more reasons. I thought that maybe I could re-arrange the order in which the hooks ran in order to fail commitlint before running the entire test suite.

Then I looked at husky and it was at version 3 in this project compared to the latest available version 7.0.1. So, I decided to upgrade while looking into hook order.

This PR just upgrades husky.

Along the way I came to understand the [git hook order](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks). `pre-commit` runs, then `prepare-commit-msg`, then `commit-msg`.

The only way to have commitlint run before linting and test suite would be to run everything in the `commit-msg` hook. I've not implemented that yet as I wanted it to be a point of discussion. I opened #308 for this question.

Meanwhile, this should bring husky up to date successfully!

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
