### PR TITLE
build: adjust dependency imports for successful build

### DIFF
--- a/packages/runtime-handler/src/dev-runtime/route.ts
+++ b/packages/runtime-handler/src/dev-runtime/route.ts
@@ -1,6 +1,7 @@
 import {
   Context,
   ServerlessCallback,
+  ServerlessEventObject,
   ServerlessFunctionSignature,
   TwilioClient,
   TwilioClientOptions,
@@ -17,6 +18,10 @@ import { join, resolve } from 'path';
 import { deserializeError } from 'serialize-error';
 import { checkForValidAccountSid } from './checks/check-account-sid';
 import { checkForValidAuthToken } from './checks/check-auth-token';
+import {
+  restrictedHeaderExactMatches,
+  restrictedHeaderPrefixes,
+} from './checks/restricted-headers';
 import { Reply } from './internal/functionRunner';
 import { Response } from './internal/response';
 import * as Runtime from './internal/runtime';
@@ -25,10 +30,6 @@ import debug from './utils/debug';
 import { wrapErrorInHtml } from './utils/error-html';
 import { requireFromProject } from './utils/requireFromProject';
 import { cleanUpStackTrace } from './utils/stack-trace/clean-up';
-import {
-  restrictedHeaderPrefixes,
-  restrictedHeaderExactMatches,
-} from './checks/restricted-headers';
 
 const log = debug('twilio-runtime-handler:dev:route');
 
@@ -75,7 +76,9 @@ export function constructHeaders(rawHeaders?: string[]): Headers {
   return {};
 }
 
-export function constructEvent<T extends {} = {}>(req: ExpressRequest): T {
+export function constructEvent<T extends ServerlessEventObject>(
+  req: ExpressRequest
+): T {
   return {
     request: {
       headers: constructHeaders(req.rawHeaders),

--- a/packages/twilio-run/package.json
+++ b/packages/twilio-run/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "@twilio-labs/serverless-api": "^5.1.1",
-    "@twilio-labs/serverless-runtime-types": "^2.1.0",
+    "@twilio-labs/serverless-runtime-types": "2.1.0-rc.0",
     "@types/express": "4.17.7",
     "@types/inquirer": "^6.0.3",
     "@types/is-ci": "^2.0.0",


### PR DESCRIPTION
<!-- Describe your Pull Request -->
This fixes two issues currently breaking the build:
1) for runtime-handler I had to adjust the type signature to use the new object that contains `{request: {cookies: {}, headers: {}}`
2) for `twilio-run` I had to pin `serverless-runtime-types` to an older version for lerna not to symlink it as `twilio-run` itself won't support the new types anymore. For this one I opened #313 to revert the change.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
