### PR TITLE
feat(create-twilio-function): add deployinfo file to gitignore

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/create-gitignore.js
+++ b/packages/create-twilio-function/src/create-twilio-function/create-gitignore.js
@@ -1,20 +1,25 @@
-const fs = require('fs');
+const fs = require('fs').promises;
+const { createWriteStream } = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
 const writeGitignore = promisify(require('gitignore').writeFile);
 
-const open = promisify(fs.open);
+const ADDITIONAL_CONTENT = `
+# Twilio Serverless
+.twiliodeployinfo
+`;
 
-function createGitignore(dirPath) {
+async function createGitignore(dirPath) {
   const fullPath = path.join(dirPath, '.gitignore');
-  return open(fullPath, 'wx').then((fd) => {
-    const stream = fs.createWriteStream(null, { fd });
-    return writeGitignore({
-      type: 'Node',
-      file: stream,
-    });
+  const fd = await fs.open(fullPath, 'wx');
+  const stream = createWriteStream(fullPath, { fd });
+  await writeGitignore({
+    type: 'Node',
+    file: stream,
   });
+  await fd.close();
+  await fs.appendFile(fullPath, ADDITIONAL_CONTENT, 'utf8');
 }
 
 module.exports = createGitignore;

--- a/packages/create-twilio-function/tests/create-gitignore.test.js
+++ b/packages/create-twilio-function/tests/create-gitignore.test.js
@@ -57,6 +57,7 @@ describe('create-gitignore', () => {
       });
       expect(contents).toMatch('*.log');
       expect(contents).toMatch('.env');
+      expect(contents).toMatch('.twiliodeployinfo');
       cleanUp();
     });
 


### PR DESCRIPTION
This change adds `.twiliodeployinfo` to the default `.gitignore`. It also refactors `createGitignore` to fully use streams and callbacks internally, but still return a Promise. More detail on the refactor in the commit message for 6b4ce35.

Fixes #318 and supersedes #319.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
