### PR TITLE
feat(create-twilio-function): add runtime-handler to js projects

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/create-files.js
+++ b/packages/create-twilio-function/src/create-twilio-function/create-files.js
@@ -27,10 +27,12 @@ const typescriptDeps = {
   '@twilio-labs/serverless-runtime-types': versions.serverlessRuntimeTypes,
   ...javaScriptDeps,
 };
-const javaScriptDevDeps = { 'twilio-run': versions.twilioRun };
-const typescriptDevDeps = {
+const javaScriptDevDeps = {
   '@twilio/runtime-handler': versions.twilioRuntimeHandler,
   'twilio-run': versions.twilioRun,
+};
+const typescriptDevDeps = {
+  ...javaScriptDevDeps,
   typescript: versions.typescript,
   copyfiles: versions.copyfiles,
 };

--- a/packages/create-twilio-function/tests/create-files.test.js
+++ b/packages/create-twilio-function/tests/create-files.test.js
@@ -79,6 +79,9 @@ describe('create-files', () => {
       expect(packageJSON.devDependencies['twilio-run']).toEqual(
         versions.twilioRun
       );
+      expect(packageJSON.devDependencies['@twilio/runtime-handler']).toEqual(
+        versions.twilioRuntimeHandler
+      );
       expect(packageJSON.dependencies['twilio']).toEqual(versions.twilio);
       cleanUp();
     });
@@ -101,6 +104,9 @@ describe('create-files', () => {
       );
       expect(packageJSON.devDependencies.typescript).toEqual(
         versions.typescript
+      );
+      expect(packageJSON.devDependencies['@twilio/runtime-handler']).toEqual(
+        versions.twilioRuntimeHandler
       );
       expect(
         packageJSON.dependencies['@twilio-labs/serverless-runtime-types']


### PR DESCRIPTION
Seems that adding the runtime handler in `create-twilio-function` only previously applied to TypeScript projects. This adds it into JavaScript projects too.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
