### PR TITLE
chore(create-twilio-function): update dependencies

### DIFF
--- a/packages/create-twilio-function/package.json
+++ b/packages/create-twilio-function/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "boxen": "^3.0.0",
     "chalk": "^2.4.2",
-    "gitignore": "^0.6.0",
+    "gitignore": "^0.7.0",
     "inquirer": "^6.2.2",
     "ora": "^3.2.0",
     "pkg-install": "^1.0.0",


### PR DESCRIPTION
This updates the gitignore dependency. Prior to 0.7.0 gitignore did not publish a license. Version 0.7.0 now comes with an MIT license.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
