### PR TITLE
chore(plugin-serverless): remove globby devDependency

### DIFF
--- a/packages/plugin-serverless/package.json
+++ b/packages/plugin-serverless/package.json
@@ -19,8 +19,7 @@
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/plugin-help": "^2.2.1",
     "@oclif/test": "^1.2.5",
-    "@twilio/cli-test": "^2.0.2",
-    "globby": "^8.0.2"
+    "@twilio/cli-test": "^2.0.2"
   },
   "engines": {
     "node": ">=12.22.1"


### PR DESCRIPTION
It does not seem to be in use, so removing from plugin-serverless.

@dkundel it looks like you added this dependency, but I can't see it in use at all. Am I missing something or can we safely remove it?

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
