### PR TITLE
fix(create-twilio-function): place runtime-handler in dependencies

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/create-files.js
+++ b/packages/create-twilio-function/src/create-twilio-function/create-files.js
@@ -22,15 +22,15 @@ async function createFile(fullPath, content) {
   return writeFile(fullPath, content, { flag: 'wx' });
 }
 
-const javaScriptDeps = { twilio: versions.twilio };
+const javaScriptDeps = {
+  twilio: versions.twilio,
+  '@twilio/runtime-handler': versions.twilioRuntimeHandler,
+};
 const typescriptDeps = {
   '@twilio-labs/serverless-runtime-types': versions.serverlessRuntimeTypes,
   ...javaScriptDeps,
 };
-const javaScriptDevDeps = {
-  '@twilio/runtime-handler': versions.twilioRuntimeHandler,
-  'twilio-run': versions.twilioRun,
-};
+const javaScriptDevDeps = { 'twilio-run': versions.twilioRun };
 const typescriptDevDeps = {
   ...javaScriptDevDeps,
   typescript: versions.typescript,

--- a/packages/create-twilio-function/tests/create-files.test.js
+++ b/packages/create-twilio-function/tests/create-files.test.js
@@ -79,7 +79,7 @@ describe('create-files', () => {
       expect(packageJSON.devDependencies['twilio-run']).toEqual(
         versions.twilioRun
       );
-      expect(packageJSON.devDependencies['@twilio/runtime-handler']).toEqual(
+      expect(packageJSON.dependencies['@twilio/runtime-handler']).toEqual(
         versions.twilioRuntimeHandler
       );
       expect(packageJSON.dependencies['twilio']).toEqual(versions.twilio);
@@ -105,7 +105,7 @@ describe('create-files', () => {
       expect(packageJSON.devDependencies.typescript).toEqual(
         versions.typescript
       );
-      expect(packageJSON.devDependencies['@twilio/runtime-handler']).toEqual(
+      expect(packageJSON.dependencies['@twilio/runtime-handler']).toEqual(
         versions.twilioRuntimeHandler
       );
       expect(

--- a/packages/twilio-run/src/commands/start.ts
+++ b/packages/twilio-run/src/commands/start.ts
@@ -1,6 +1,7 @@
 import { Server } from 'http';
 import inquirer from 'inquirer';
 import { Argv } from 'yargs';
+import { checkForValidRuntimeHandlerVersion } from '../checks/check-runtime-handler';
 import checkLegacyConfig from '../checks/legacy-config';
 import checkNodejsVersion from '../checks/nodejs-version';
 import checkProjectStructure from '../checks/project-structure';
@@ -47,6 +48,11 @@ export async function handler(
   await checkLegacyConfig(argv.cwd, false);
 
   const config = await getConfigFromCli(argv, cliInfo, externalCliOptions);
+
+  if (config.pkgJson && !checkForValidRuntimeHandlerVersion(config.pkgJson)) {
+    process.exitCode = 1;
+    return;
+  }
 
   const command = getFullCommand(argv);
   const directories = {

--- a/packages/twilio-run/src/commands/start.ts
+++ b/packages/twilio-run/src/commands/start.ts
@@ -49,7 +49,7 @@ export async function handler(
 
   const config = await getConfigFromCli(argv, cliInfo, externalCliOptions);
 
-  if (config.pkgJson && !checkForValidRuntimeHandlerVersion(config.pkgJson)) {
+  if (!checkForValidRuntimeHandlerVersion(config.pkgJson)) {
     process.exitCode = 1;
     return;
   }

--- a/packages/twilio-run/src/config/start.ts
+++ b/packages/twilio-run/src/config/start.ts
@@ -9,8 +9,10 @@ import { AllAvailableFlagTypes, SharedFlagNames } from '../flags';
 import { EnvironmentVariablesWithAuth } from '../types/generic';
 import { fileExists } from '../utils/fs';
 import { getDebugFunction, logger } from '../utils/logger';
+import { readPackageJsonContent } from './utils';
 import { readSpecializedConfig } from './global';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
+import { PackageJson } from 'type-fest';
 
 const debug = getDebugFunction('twilio-run:cli:config');
 
@@ -38,6 +40,7 @@ export type StartCliConfig = {
   assetsFolderName?: string;
   functionsFolderName?: string;
   forkProcess: boolean;
+  pkgJson?: PackageJson;
 };
 
 export type ConfigurableStartCliFlags = Pick<
@@ -172,6 +175,8 @@ export async function getConfigFromCli(
   const cli = mergeFlagsAndConfig<StartCliFlags>(configFlags, flags, cliInfo);
   const config = {} as StartCliConfig;
 
+  const pkgJson = await readPackageJsonContent(flags);
+
   config.inspect = getInspectInfo(cli);
   config.baseDir = getBaseDirectory(cli);
   config.env = await getEnvironment(cli, config.baseDir);
@@ -184,6 +189,7 @@ export async function getConfigFromCli(
   config.assetsFolderName = cli.assetsFolder;
   config.functionsFolderName = cli.functionsFolder;
   config.forkProcess = cli.forkProcess;
+  config.pkgJson = pkgJson;
 
   return config;
 }

--- a/packages/twilio-run/src/config/start.ts
+++ b/packages/twilio-run/src/config/start.ts
@@ -40,7 +40,7 @@ export type StartCliConfig = {
   assetsFolderName?: string;
   functionsFolderName?: string;
   forkProcess: boolean;
-  pkgJson?: PackageJson;
+  pkgJson: PackageJson;
 };
 
 export type ConfigurableStartCliFlags = Pick<

--- a/packages/twilio-run/src/config/start.ts
+++ b/packages/twilio-run/src/config/start.ts
@@ -163,19 +163,16 @@ export async function getConfigFromCli(
   cliInfo: CliInfo = { options: {} },
   externalCliOptions?: ExternalCliOptions
 ): Promise<StartCliConfig> {
-  const configFlags = readSpecializedConfig(
-    flags.cwd || process.cwd(),
-    flags.config,
-    'start',
-    {
-      username:
-        (externalCliOptions && externalCliOptions.accountSid) || undefined,
-    }
-  ) as StartCliFlags;
+  let cwd = flags.cwd ? path.resolve(flags.cwd) : process.cwd();
+  flags.cwd = cwd;
+  const configFlags = readSpecializedConfig(cwd, flags.config, 'start', {
+    username:
+      (externalCliOptions && externalCliOptions.accountSid) || undefined,
+  }) as StartCliFlags;
   const cli = mergeFlagsAndConfig<StartCliFlags>(configFlags, flags, cliInfo);
   const config = {} as StartCliConfig;
 
-  const pkgJson = await readPackageJsonContent(flags);
+  const pkgJson = await readPackageJsonContent(cli);
 
   config.inspect = getInspectInfo(cli);
   config.baseDir = getBaseDirectory(cli);


### PR DESCRIPTION
Not in devDependencies.

Also perform check on location of @twilio/runtime-handler at start as well as deploy time.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
