### PR TITLE
chore(assets): don't use flag default for service-name

### DIFF
--- a/packages/plugin-assets/src/commands/assets/init.js
+++ b/packages/plugin-assets/src/commands/assets/init.js
@@ -16,7 +16,8 @@ class InitCommand extends TwilioClientCommand {
         accountSid: this.currentProfile.accountSid,
         pluginConfig: pluginConfig,
         logger: this.logger,
-        serviceName: this.flags['service-name'],
+        serviceName:
+          this.flags['service-name'].trim() || generateProjectName().dashed,
       });
       this.output(result, this.flags.properties);
     } catch (error) {
@@ -29,7 +30,6 @@ InitCommand.flags = {
   'service-name': flags.string({
     description:
       'A unique name for your asset service. May only contain alphanumeric characters and hyphens.',
-    default: () => generateProjectName().dashed,
   }),
   properties: flags.string({
     default: 'service_sid, sid, domain_name',


### PR DESCRIPTION
This was generating new and not exactly accurate defaults into the README for the plugin. This moves the project name generation out of being a default flag and to generate only if no name is passed.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
