### PR TITLE
fix(twilio-run): expose env set and import commands

### DIFF
--- a/packages/twilio-run/src/cli.ts
+++ b/packages/twilio-run/src/cli.ts
@@ -22,8 +22,10 @@ export async function run(rawArgs: string[]) {
       'Retrieve and modify the environment variables for your deployment',
       (yargs) => {
         yargs.command(EnvCommands.GetCommand);
+        yargs.command(EnvCommands.SetCommand);
         yargs.command(EnvCommands.ListCommand);
         yargs.command(EnvCommands.UnsetCommand);
+        yargs.command(EnvCommands.ImportCommand);
       }
     )
     .parse(rawArgs.slice(2));


### PR DESCRIPTION
The "env set" and "env get" commands were not previously exposed in twilio-run and only in

fix #339

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
