### PR TITLE
Json output

### DIFF
--- a/packages/runtime-handler/src/dev-runtime/server.ts
+++ b/packages/runtime-handler/src/dev-runtime/server.ts
@@ -1,6 +1,6 @@
 import { ServerlessFunctionSignature } from '@twilio-labs/serverless-runtime-types/types';
 import bodyParser from 'body-parser';
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import express, {
   Express,
   NextFunction,

--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -30,7 +30,7 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"logLevel\\": \\"info\\" 	/* Level of logging messages. */,
 	// \\"logs\\": true 	/* Toggles request logging */,
 	// \\"ngrok\\": null 	/* Uses ngrok to create a public url. Pass a string to set the subdomain (requires a paid-for ngrok account). */,
-	// \\"outputFormat\\": \\"\\" 	/* Output the log in a different format */,
+	// \\"outputFormat\\": \\"\\" 	/* Output the results in a different format */,
 	// \\"overrideExistingProject\\": false 	/* Deploys Serverless project to existing service if a naming conflict has been found. */,
 	// \\"port\\": \\"3000\\" 	/* Override default port of 3000 */,
 	// \\"production\\": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,

--- a/packages/twilio-run/src/commands/deploy.ts
+++ b/packages/twilio-run/src/commands/deploy.ts
@@ -115,7 +115,7 @@ export async function handler(
 
   checkConfigForCredentials(config);
 
-  printConfigInfo(config);
+  printConfigInfo(config, config.outputFormat);
 
   const spinner = getOraSpinner('Deploying Function').start();
   try {
@@ -126,7 +126,7 @@ export async function handler(
     const result = await client.deployLocalProject(config);
     spinner.text = 'Serverless project successfully deployed\n';
     spinner.succeed();
-    printDeployedResources(config, result);
+    printDeployedResources(config, result, config.outputFormat);
     const { serviceSid, buildSid } = result;
     await saveLatestDeploymentData(
       config.cwd,
@@ -156,6 +156,7 @@ export const cliInfo: CliInfo = {
       'assets-folder',
       'functions-folder',
       'runtime',
+      'output-format',
     ]),
     production: {
       ...ALL_FLAGS['production'],

--- a/packages/twilio-run/src/commands/list.ts
+++ b/packages/twilio-run/src/commands/list.ts
@@ -71,7 +71,7 @@ export async function handler(
   try {
     const client = new TwilioServerlessApiClient(config);
     const result = await client.list({ ...config });
-    printListResult(result, config);
+    printListResult(result, config, config.outputFormat);
   } catch (err) {
     handleError(err);
   }
@@ -89,6 +89,7 @@ export const cliInfo: CliInfo = {
       'properties',
       'extended-output',
       'service-sid',
+      'output-format',
     ]),
     environment: {
       ...ALL_FLAGS['environment'],

--- a/packages/twilio-run/src/commands/promote.ts
+++ b/packages/twilio-run/src/commands/promote.ts
@@ -78,7 +78,7 @@ export async function handler(
 
   checkConfigForCredentials(config);
 
-  printActivateConfig(config);
+  printActivateConfig(config, config.outputFormat);
 
   const details = config.buildSid
     ? `(${config.buildSid})`
@@ -90,10 +90,11 @@ export async function handler(
     const client = new TwilioServerlessApiClient(config);
     const result = await client.activateBuild(config);
     spinner.succeed(
-      `Activated new build ${details} on ${config.targetEnvironment ||
-        'production'}`
+      `Activated new build ${details} on ${
+        config.targetEnvironment || 'production'
+      }`
     );
-    printActivateResult(result);
+    printActivateResult(result, config.outputFormat);
   } catch (err) {
     handleError(err, spinner);
   }
@@ -112,6 +113,7 @@ export const cliInfo: CliInfo = {
       'create-environment',
       'force',
       'env',
+      'output-format',
     ]),
   },
 };

--- a/packages/twilio-run/src/commands/shared.ts
+++ b/packages/twilio-run/src/commands/shared.ts
@@ -11,3 +11,5 @@ export type ExternalCliOptions = {
     version: string;
   };
 };
+
+export type OutputFormat = string | undefined;

--- a/packages/twilio-run/src/config/deploy.ts
+++ b/packages/twilio-run/src/config/deploy.ts
@@ -23,6 +23,7 @@ import { getUserAgentExtensions } from './utils/userAgentExtensions';
 export type DeployLocalProjectConfig = ApiDeployLocalProjectConfig & {
   username: string;
   password: string;
+  outputFormat?: string;
 };
 
 export type ConfigurableDeployCliFlags = Pick<
@@ -39,6 +40,7 @@ export type ConfigurableDeployCliFlags = Pick<
   | 'assetsFolder'
   | 'functionsFolder'
   | 'runtime'
+  | 'outputFormat'
 >;
 export type DeployCliFlags = Arguments<
   ConfigurableDeployCliFlags & {
@@ -112,6 +114,7 @@ export async function getConfigFromFlags(
   }
 
   const { region, edge, runtime } = flags;
+  const outputFormat = flags.outputFormat || externalCliOptions?.outputFormat;
 
   return {
     cwd,
@@ -133,5 +136,6 @@ export async function getConfigFromFlags(
     edge,
     runtime,
     userAgentExtensions: getUserAgentExtensions('deploy', externalCliOptions),
+    outputFormat,
   };
 }

--- a/packages/twilio-run/src/config/list.ts
+++ b/packages/twilio-run/src/config/list.ts
@@ -26,6 +26,7 @@ export type ListConfig = ApiListConfig & {
   cwd: string;
   properties?: string[];
   extendedOutput: boolean;
+  outputFormat?: string;
 };
 
 export type ConfigurableListCliFlags = Pick<
@@ -36,6 +37,7 @@ export type ConfigurableListCliFlags = Pick<
   | 'extendedOutput'
   | 'environment'
   | 'serviceSid'
+  | 'outputFormat'
 >;
 export type ListCliFlags = Arguments<
   ConfigurableListCliFlags & {
@@ -91,6 +93,7 @@ export async function getConfigFromFlags(
   const types = flags.types.split(',').map(trim) as ListOptions[];
   const region = flags.region;
   const edge = flags.edge;
+  const outputFormat = flags.outputFormat || externalCliOptions?.outputFormat;
 
   return {
     cwd,
@@ -106,6 +109,7 @@ export async function getConfigFromFlags(
     types,
     region,
     edge,
+    outputFormat,
     userAgentExtensions: getUserAgentExtensions('list', externalCliOptions),
   };
 }

--- a/packages/twilio-run/src/config/promote.ts
+++ b/packages/twilio-run/src/config/promote.ts
@@ -23,6 +23,7 @@ export type PromoteConfig = ApiActivateConfig & {
   cwd: string;
   username: string;
   password: string;
+  outputFormat?: string;
 };
 
 export type ConfigurablePromoteCliFlags = Pick<
@@ -35,6 +36,7 @@ export type ConfigurablePromoteCliFlags = Pick<
   | 'production'
   | 'createEnvironment'
   | 'force'
+  | 'outputFormat'
 >;
 export type PromoteCliFlags = Arguments<ConfigurablePromoteCliFlags>;
 
@@ -86,6 +88,7 @@ export async function getConfigFromFlags(
   const serviceSid = checkForValidServiceSid(command, potentialServiceSid);
   const region = flags.region;
   const edge = flags.edge;
+  const outputFormat = flags.outputFormat || externalCliOptions?.outputFormat;
 
   return {
     cwd,
@@ -101,5 +104,6 @@ export async function getConfigFromFlags(
     edge,
     env,
     userAgentExtensions: getUserAgentExtensions('promote', externalCliOptions),
+    outputFormat,
   };
 }

--- a/packages/twilio-run/src/flags.ts
+++ b/packages/twilio-run/src/flags.ts
@@ -159,7 +159,7 @@ export const ALL_FLAGS = {
     type: 'string',
     alias: 'o',
     default: '',
-    describe: 'Output the log in a different format',
+    describe: 'Output the results in a different format',
     choices: ['', 'json'],
   } as Options,
   'log-cache-size': {
@@ -251,9 +251,9 @@ export const ALL_FLAGS = {
 export type AvailableFlags = typeof ALL_FLAGS;
 export type FlagNames = keyof AvailableFlags;
 
-export function getRelevantFlags(
-  flags: FlagNames[]
-): { [flagName: string]: Options } {
+export function getRelevantFlags(flags: FlagNames[]): {
+  [flagName: string]: Options;
+} {
   return flags.reduce((current: { [flagName: string]: Options }, flagName) => {
     return { ...current, [flagName]: { ...ALL_FLAGS[flagName] } };
   }, {});

--- a/packages/twilio-run/src/printers/activate.ts
+++ b/packages/twilio-run/src/printers/activate.ts
@@ -2,12 +2,20 @@ import { ActivateResult } from '@twilio-labs/serverless-api';
 import { stripIndent } from 'common-tags';
 import { PromoteConfig } from '../config/promote';
 import { logger } from '../utils/logger';
-import { writeOutput } from '../utils/output';
+import { writeJSONOutput, writeOutput } from '../utils/output';
 import { getTwilioConsoleDeploymentUrl, redactPartOfString } from './utils';
 import chalk = require('chalk');
 import terminalLink = require('terminal-link');
+import { ConfigurationContext } from 'twilio/lib/rest/conversations/v1/configuration';
+import { OutputFormat } from '../commands/shared';
 
-export function printActivateConfig(config: PromoteConfig) {
+export function printActivateConfig(
+  config: PromoteConfig,
+  outputFormat: OutputFormat
+) {
+  if (outputFormat === 'json') {
+    return;
+  }
   const message = chalk`
     {cyan.bold Username} ${config.username}
     {cyan.bold Password} ${redactPartOfString(config.password)}
@@ -15,7 +23,14 @@ export function printActivateConfig(config: PromoteConfig) {
   logger.info(stripIndent(message) + '\n');
 }
 
-export function printActivateResult(result: ActivateResult) {
+export function printActivateResult(
+  result: ActivateResult,
+  outputFormat: OutputFormat
+) {
+  if (outputFormat === 'json') {
+    writeJSONOutput(result);
+    return;
+  }
   logger.info(chalk.cyan.bold('\nActive build available at:'));
   writeOutput(result.domain);
 

--- a/packages/twilio-run/src/printers/deploy.ts
+++ b/packages/twilio-run/src/printers/deploy.ts
@@ -8,9 +8,10 @@ import columnify from 'columnify';
 import { stripIndent } from 'common-tags';
 import terminalLink from 'terminal-link';
 import { MergeExclusive } from 'type-fest';
+import { OutputFormat } from '../commands/shared';
 import { DeployLocalProjectConfig } from '../config/deploy';
 import { logger } from '../utils/logger';
-import { writeOutput } from '../utils/output';
+import { writeJSONOutput, writeOutput } from '../utils/output';
 import {
   getTwilioConsoleDeploymentUrl,
   printObjectWithoutHeaders,
@@ -186,7 +187,13 @@ function prettyPrintDeployedResources(
   }
 }
 
-export function printConfigInfo(config: DeployLocalProjectConfig) {
+export function printConfigInfo(
+  config: DeployLocalProjectConfig,
+  outputFormat: OutputFormat
+) {
+  if (outputFormat === 'json') {
+    return;
+  }
   if (shouldPrettyPrint) {
     prettyPrintConfigInfo(config);
   } else {
@@ -196,8 +203,13 @@ export function printConfigInfo(config: DeployLocalProjectConfig) {
 
 export function printDeployedResources(
   config: DeployLocalProjectConfig,
-  result: DeployResult
+  result: DeployResult,
+  outputFormat: OutputFormat
 ) {
+  if (outputFormat === 'json') {
+    writeJSONOutput(result);
+    return;
+  }
   if (shouldPrettyPrint) {
     prettyPrintDeployedResources(config, result);
   } else {

--- a/packages/twilio-run/src/printers/env/env-list.ts
+++ b/packages/twilio-run/src/printers/env/env-list.ts
@@ -1,13 +1,13 @@
 import { GetEnvironmentVariablesResult } from '@twilio-labs/serverless-api';
 import chalk from 'chalk';
-import { writeOutput } from '../../utils/output';
+import { writeJSONOutput, writeOutput } from '../../utils/output';
 
 export function outputVariables(
   result: GetEnvironmentVariablesResult,
   format?: 'json'
 ) {
   if (format === 'json') {
-    writeOutput(JSON.stringify(result, null, '\t'));
+    writeJSONOutput(result);
   } else {
     const output = result.variables
       .map((entry: { [key: string]: string | undefined }) => {

--- a/packages/twilio-run/src/printers/list.ts
+++ b/packages/twilio-run/src/printers/list.ts
@@ -14,9 +14,10 @@ import { stripIndent } from 'common-tags';
 import startCase from 'lodash.startcase';
 import logSymbols from 'log-symbols';
 import title from 'title';
+import { OutputFormat } from '../commands/shared';
 import { ListConfig } from '../config/list';
 import { logger } from '../utils/logger';
-import { writeOutput } from '../utils/output';
+import { writeJSONOutput, writeOutput } from '../utils/output';
 import { redactPartOfString, shouldPrettyPrint, windowSize } from './utils';
 
 type KeyMaps = {
@@ -292,7 +293,7 @@ function prettyPrintSection<T extends ListOptions>(
 function printListResultTerminal(result: ListResult, config: ListConfig): void {
   const sections = Object.keys(result) as ListOptions[];
   const output = sections
-    .map(section => prettyPrintSection(section, result[section]))
+    .map((section) => prettyPrintSection(section, result[section]))
     .join(`\n\n${chalk.dim(LONG_LINE)}\n\n`);
 
   let metaInfo = stripIndent(chalk`
@@ -301,8 +302,9 @@ function printListResultTerminal(result: ListResult, config: ListConfig): void {
   `);
 
   if (config.serviceSid || config.serviceName) {
-    metaInfo += chalk`\n{cyan.bold Service}      ${config.serviceSid ||
-      config.serviceName}`;
+    metaInfo += chalk`\n{cyan.bold Service}      ${
+      config.serviceSid || config.serviceName
+    }`;
   }
 
   if (config.environment) {
@@ -313,7 +315,15 @@ function printListResultTerminal(result: ListResult, config: ListConfig): void {
   writeOutput(output);
 }
 
-export function printListResult(result: ListResult, config: ListConfig): void {
+export function printListResult(
+  result: ListResult,
+  config: ListConfig,
+  outputFormat: OutputFormat
+): void {
+  if (outputFormat === 'json') {
+    writeJSONOutput(result);
+    return;
+  }
   if (shouldPrettyPrint && !config.properties && !config.extendedOutput) {
     printListResultTerminal(result, config);
   } else {

--- a/packages/twilio-run/src/utils/output.ts
+++ b/packages/twilio-run/src/utils/output.ts
@@ -1,3 +1,7 @@
 export function writeOutput(...args: any[]) {
   console.log(...args);
 }
+
+export function writeJSONOutput(...args: any[]) {
+  writeOutput(JSON.stringify(args, null, '\t'));
+}

--- a/packages/twilio-run/src/utils/output.ts
+++ b/packages/twilio-run/src/utils/output.ts
@@ -2,6 +2,6 @@ export function writeOutput(...args: any[]) {
   console.log(...args);
 }
 
-export function writeJSONOutput(...args: any[]) {
-  writeOutput(JSON.stringify(args, null, '\t'));
+export function writeJSONOutput(obj: any) {
+  writeOutput(JSON.stringify(obj, null, '\t'));
 }


### PR DESCRIPTION
Adds an `--output-format` (or `-o`) flag to the `deploy`, `list-templates`, `list` and `promote` commands. Commands that already supported this flag include `logs` and `env:list`. Commands that do not support an output format currently include `new` and `start`.

This supersedes #143.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
