### PR TITLE
fix(create-twilio-function): adds rootDir to generated tsconfig.json

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/create-files.js
+++ b/packages/create-twilio-function/src/create-twilio-function/create-files.js
@@ -130,6 +130,7 @@ function createTsconfigFile(pathName) {
           module: 'commonjs',
           strict: true,
           esModuleInterop: true,
+          rootDir: 'src',
           outDir: 'dist',
           skipLibCheck: true,
           sourceMap: true,


### PR DESCRIPTION
By default, tsc deems the lowest common directory as the root directory
of the application and delivers the compiled files into the outDir.
If you do not have an `assets` directory with a .ts file in it, then tsc
deems src/functions as the root directory and puts the compiled
functions directly into the `dist` directory. This wasn't obvious,
because the example generated files included a private TS asset.

Setting the `rootDir` to "src" ensures that the base directory is "src"
and a "functions" directory is generated in `dist`.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
