### PR TITLE
feat: Merge type files into bundle

### DIFF
--- a/packages/serverless-runtime-types/bundler.js
+++ b/packages/serverless-runtime-types/bundler.js
@@ -6,8 +6,7 @@ const fs = require('fs')
 
 const indexFile = fs.readFileSync('index.d.ts', 'utf8');
 // remove all import statements from index.d.ts
-const indexFileNoImports = indexFile.replace(/import .*([\S\s]*?);/g, "");
+const indexFileNoImports = indexFile.replace(/import .*?;/gs, '');
 const typesFile = fs.readFileSync('types.d.ts', 'utf8');
 
-fs.writeFileSync('bundle.d.ts', typesFile.trim());
-fs.appendFileSync('bundle.d.ts', indexFileNoImports);
+fs.writeFileSync('bundle.d.ts', typesFile + '\n' + indexFileNoImports.trim());

--- a/packages/serverless-runtime-types/bundler.js
+++ b/packages/serverless-runtime-types/bundler.js
@@ -1,0 +1,13 @@
+// Script to merge all the types files into bundle.d.ts
+// bundle.d.ts can be added into Monaco/react editor, until Monaco supports
+// importing multiple files.
+
+const fs = require('fs')
+
+const indexFile = fs.readFileSync('index.d.ts', 'utf8');
+// remove all import statements from index.d.ts
+const indexFileNoImports = indexFile.replace(/import .*([\S\s]*?);/g, "");
+const typesFile = fs.readFileSync('types.d.ts', 'utf8');
+
+fs.writeFileSync('bundle.d.ts', typesFile.trim());
+fs.appendFileSync('bundle.d.ts', indexFileNoImports);

--- a/packages/serverless-runtime-types/bundler.sh
+++ b/packages/serverless-runtime-types/bundler.sh
@@ -3,9 +3,7 @@
 # bundle.d.ts can be added into Monaco/react editor, until Monaco supports
 # importing multiple files.
 
-# Remove the import statements from index.d.ts and save it to index.temp.d.ts
-awk -v RS= '!/^import /' ORS='\n\n' index.d.ts > index.temp.d.ts
-# Merge types.d.ts and index.temp.d.ts into bundle.d.ts
-(echo "$(cat types.d.ts)"; echo; echo "$(cat index.temp.d.ts)") > bundle.d.ts
-# Remvoe the temp file
-rm -f index.temp.d.ts
+# Append types.d.ts into bundle.d.ts
+(cat types.d.ts && echo) > bundle.d.ts
+# Remove the import statements from index.d.ts and append it to bundle.d.ts
+(awk -v RS= '!/^import /' ORS='\n' index.d.ts) >> bundle.d.ts

--- a/packages/serverless-runtime-types/bundler.sh
+++ b/packages/serverless-runtime-types/bundler.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# Shell script to merge all the types files into bundle.d.ts
-# bundle.d.ts can be added into Monaco/react editor, until Monaco supports
-# importing multiple files.
-
-# Append types.d.ts into bundle.d.ts
-(cat types.d.ts && echo) > bundle.d.ts
-# Remove the import statements from index.d.ts and append it to bundle.d.ts
-(awk -v RS= '!/^import /' ORS='\n' index.d.ts) >> bundle.d.ts

--- a/packages/serverless-runtime-types/bundler.sh
+++ b/packages/serverless-runtime-types/bundler.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+awk -v RS= '!/^import /' ORS='\n\n' index.d.ts > index.temp.d.ts
+(echo "$(cat types.d.ts)"; echo; echo "$(cat index.temp.d.ts)") > bundle.d.ts
+rm -f index.temp.d.ts

--- a/packages/serverless-runtime-types/bundler.sh
+++ b/packages/serverless-runtime-types/bundler.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+# Shell script to merge all the types files into bundle.d.ts
+# bundle.d.ts can be added into Monaco/react editor, until Monaco supports
+# importing multiple files.
+
+# Remove the import statements from index.d.ts and save it to index.temp.d.ts
 awk -v RS= '!/^import /' ORS='\n\n' index.d.ts > index.temp.d.ts
+# Merge types.d.ts and index.temp.d.ts into bundle.d.ts
 (echo "$(cat types.d.ts)"; echo; echo "$(cat index.temp.d.ts)") > bundle.d.ts
+# Remvoe the temp file
 rm -f index.temp.d.ts

--- a/packages/serverless-runtime-types/package.json
+++ b/packages/serverless-runtime-types/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "sh bundler.sh"
+    "build": "sh bundler.sh",
+    "prepare": "npm run-script build"
   },
   "keywords": [
     "twilio",

--- a/packages/serverless-runtime-types/package.json
+++ b/packages/serverless-runtime-types/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "sh bundler.sh",
+    "build": "./bundler.sh",
     "prepare": "npm run-script build"
   },
   "keywords": [

--- a/packages/serverless-runtime-types/package.json
+++ b/packages/serverless-runtime-types/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "sh bundler.sh"
   },
   "keywords": [
     "twilio",
@@ -41,7 +42,8 @@
     "README.md",
     "index.js",
     "index.d.ts",
-    "types.d.ts"
+    "types.d.ts",
+    "bundle.d.ts"
   ],
   "gitHead": "9382ba7f1c23cdf18ac8bb6cada92340d63491dd"
 }

--- a/packages/serverless-runtime-types/package.json
+++ b/packages/serverless-runtime-types/package.json
@@ -6,8 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./bundler.sh",
-    "prepare": "npm run-script build"
+    "build": "node bundler.js",
+    "prepack": "npm run build"
   },
   "keywords": [
     "twilio",


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Currently, `Monaco` does not support importing multiple files.

This PR adds a script which merges `index.d.ts` and `types.d.ts` into `bundle.d.ts`.
Script is run at `npm prepare` stage.
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
