### PR TITLE
Fix for #371

### DIFF
--- a/packages/runtime-handler/__tests__/dev-runtime/__snapshots__/integration.test.ts.snap
+++ b/packages/runtime-handler/__tests__/dev-runtime/__snapshots__/integration.test.ts.snap
@@ -38,6 +38,25 @@ Object {
 }
 `;
 
+exports[`with an express app with inline function handling Assets integration tests index.html should match snapshot 1`] = `
+Object {
+  "body": Object {},
+  "headers": Object {
+    "accept-ranges": "bytes",
+    "cache-control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+    "connection": "close",
+    "content-type": "text/html; charset=UTF-8",
+    "expires": "0",
+    "pragma": "no-cache",
+    "surrogate-control": "no-store",
+    "x-powered-by": "Express",
+  },
+  "statusCode": 200,
+  "text": "<html><body>Hi there!</body></html>",
+  "type": "text/html",
+}
+`;
+
 exports[`with an express app with inline function handling Function integration tests basic-twiml.js should match snapshot 1`] = `
 Object {
   "body": Object {},

--- a/packages/runtime-handler/__tests__/dev-runtime/integration.test.ts
+++ b/packages/runtime-handler/__tests__/dev-runtime/integration.test.ts
@@ -161,6 +161,69 @@ describe('with an express app', () => {
     });
   });
 
+  describe('asset fallback', () => {
+    test('serves /assets/index.html if no root exists', async () => {
+      const app = new LocalDevelopmentServer(9000, {
+        ...BASE_CONFIG,
+        routes: {
+          assets: [
+            {
+              name: '/assets/index.html',
+              path: '/assets/index.html',
+              filePath: resolve(TEST_ASSETS_DIR, 'index.html'),
+              content: '',
+              access: 'public',
+            },
+          ],
+          functions: [],
+        },
+        forkProcess: false,
+      } as ServerConfig).getApp();
+
+      const response = await request(app).get('/');
+      expect(response.statusCode).toEqual(200);
+      expect(response.text).toEqual('<html><body>Hi there!</body></html>');
+    });
+
+    test('returns 404 if no /assets/index.html & no root exists', async () => {
+      const app = new LocalDevelopmentServer(9000, {
+        ...BASE_CONFIG,
+        routes: {
+          assets: [],
+          functions: [],
+        },
+        forkProcess: false,
+      } as ServerConfig).getApp();
+
+      const response = await request(app).get('/');
+      expect(response.statusCode).toEqual(404);
+      expect(response.text).toEqual('Could not find requested resource');
+    });
+
+    test('returns root if it exists', async () => {
+      const app = new LocalDevelopmentServer(9000, {
+        ...BASE_CONFIG,
+        routes: {
+          assets: [
+            {
+              name: '/',
+              path: '/',
+              filePath: resolve(TEST_ASSETS_DIR, 'index.html'),
+              content: '',
+              access: 'public',
+            },
+          ],
+          functions: [],
+        },
+        forkProcess: false,
+      } as ServerConfig).getApp();
+
+      const response = await request(app).get('/');
+      expect(response.statusCode).toEqual(200);
+      expect(response.text).toEqual('<html><body>Hi there!</body></html>');
+    });
+  });
+
   describe('with forked process function handling', () => {
     beforeAll(async () => {
       app = new LocalDevelopmentServer(9000, {

--- a/packages/runtime-handler/fixtures/assets/index.html
+++ b/packages/runtime-handler/fixtures/assets/index.html
@@ -1,0 +1,1 @@
+<html><body>Hi there!</body></html>

--- a/packages/runtime-handler/src/dev-runtime/server.ts
+++ b/packages/runtime-handler/src/dev-runtime/server.ts
@@ -141,12 +141,15 @@ export class LocalDevelopmentServer extends EventEmitter {
     app.all(
       '/*',
       (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
-        if (!this.routeMap.has(req.path)) {
-          res.status(404).send('Could not find request resource');
-          return;
+        let routeInfo = this.routeMap.get(req.path);
+
+        if (!routeInfo && req.path === '/') {
+          log('Falling back to /assets/index.html');
+          // In production we automatically fall back to the contents of /assets/index.html
+          routeInfo = this.routeMap.get('/assets/index.html');
         }
 
-        if (req.method === 'OPTIONS') {
+        if (req.method === 'OPTIONS' && routeInfo) {
           res.set({
             'access-control-allow-origin': '*',
             'access-control-allow-headers':
@@ -162,8 +165,6 @@ export class LocalDevelopmentServer extends EventEmitter {
 
           return;
         }
-
-        const routeInfo = this.routeMap.get(req.path);
 
         if (routeInfo && routeInfo.type === 'function') {
           const functionPath = routeInfo.filePath;


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This PR implements the existing logic for how `/` will fallback to `/assets/index.html` in production.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
