### PR TITLE
docs: add TSDoc comments to runtime typedefs

### DIFF
--- a/packages/serverless-runtime-types/types.d.ts
+++ b/packages/serverless-runtime-types/types.d.ts
@@ -26,7 +26,7 @@ export interface TwilioResponse {
    * Set the status code of the response.
    *
    * @param code - Integer value of the status code
-   * @returns This Response object to enable method chaining
+   * @returns This `TwilioResponse` object to enable method chaining
    *
    * @see https://www.twilio.com/docs/runtime/functions/invocation#twilio-response-methods
    *
@@ -46,7 +46,7 @@ export interface TwilioResponse {
    * Set the body of the response. Takes either a string or an object.
    *
    * @param body - The body of the response
-   * @returns This Response object to enable method chaining
+   * @returns This `TwilioResponse` object to enable method chaining
    *
    * @see https://www.twilio.com/docs/runtime/functions/invocation#twilio-response-methods
    *
@@ -74,13 +74,13 @@ export interface TwilioResponse {
    */
   setBody(body: string | object): TwilioResponse;
   /**
-   * Adds a header to the HTTP response. The first argument specifies the header name and the second argument the header value.
+   * Add a header to the HTTP response. The first argument specifies the header name and the second argument the header value.
    *
    * If Response.appendHeader is called with the name of a header that already exists on this Response object, that header will be converted from a string to an array, and the provided value will be concatenated to that array of values.
    *
    * @param key - The name of the header
    * @param value - The value of the header
-   * @returns This Response object to enable method chaining
+   * @returns This `TwilioResponse` object to enable method chaining
    *
    * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responseappendheaderkey-value
    *
@@ -114,7 +114,7 @@ export interface TwilioResponse {
    * You may also set multi-value headers by making the intended header an array.
    *
    * @param headers - An object of headers to append to the response. Can include set-cookie
-   * @returns This Response object to enable method chaining
+   * @returns This `TwilioResponse` object to enable method chaining
    *
    * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responsesetheadersheaders
    *
@@ -142,7 +142,7 @@ export interface TwilioResponse {
    * @param key - The name of the cookie to be set
    * @param value - The value of the cookie
    * @param attributes - Optional attributes to assign to the cookie
-   * @returns This Response object to enable method chaining
+   * @returns This `TwilioResponse` object to enable method chaining
    *
    * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responsesetcookiekey-value-attributes
    *
@@ -169,7 +169,7 @@ export interface TwilioResponse {
    * Accepts the name of the cookie to be removed, and sets the Max-Age attribute of the cookie equal to 0 so that clients and browsers will remove the cookie upon receiving the response.
    *
    * @param key - The name of the cookie to be removed
-   * @returns This Response object to enable method chaining
+   * @returns This `TwilioResponse` object to enable method chaining
    *
    * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responseremovecookiekey
    *
@@ -234,7 +234,7 @@ export type RuntimeInstance = {
    * Each Function name serves as the key to a Function object that contains the path to that Function.
    * These paths can be used to import code from other Functions and to compose code hosted on Twilio Functions.
    *
-   * @returns Key-value pairs of Asset names and Asset objects
+   * @returns Key-value pairs of Function names and Function objects
    *
    * @see https://www.twilio.com/docs/runtime/client#runtimegetfunctions
    *
@@ -264,10 +264,10 @@ export type RuntimeInstance = {
    */
   getFunctions(): ResourceMap;
   /**
-   * Returns a Sync Service object that has been configured to work with your default Sync Service
+   * Returns a Sync Service Context object that has been configured to work with your default Sync Service
    *
-   * @param options - Optional options object to configure the Sync Client, such as the name of a different Sync Service
-   * @returns A Sync Client
+   * @param options - Optional object to configure the Sync Context, such as the name of a different Sync Service
+   * @returns A Sync Context object for interacting with Twilio Sync
    *
    * @see https://www.twilio.com/docs/runtime/client#runtimegetsyncoptions
    *
@@ -318,10 +318,53 @@ export type RuntimeInstance = {
 };
 
 export type Context<T = {}> = {
+  /**
+   * If you have enabled the inclusion of your account credentials in your Function, this will return an initialized Twilio REST Helper Library. If you have not included account credentials in your Function, calling this method will result in an error.
+   *
+   * @param options - Optional object to configure the Twilio Client, such as enabling lazy loading
+   * @returns An initialized Twilio Client
+   *
+   * @see https://www.twilio.com/docs/runtime/functions/invocation#helper-methods
+   *
+   * Usage of context.getTwilioClient() to get an initialized Twilio Client and send a SMS.
+   * ```ts
+   * exports.handler = function (context, event, callback) {
+   *   // Fetch already initialized Twilio REST client
+   *   const twilioClient = context.getTwilioClient();
+   *   // Determine message details from the incoming event, with fallback values
+   *   const from = event.From || '+15095550100';
+   *   const to = event.To || '+15105550101';
+   *   const body = event.Body || 'Ahoy, World!';
+   *
+   *   twilioClient.messages
+   *     .create({ to, from, body })
+   *     .then((result) => {
+   *       console.log('Created message using callback: ', result.sid);
+   *       return callback();
+   *     })
+   *     .catch((error) => {
+   *       console.error(error);
+   *       return callback(error);
+   *     });
+   * };
+   * ```
+   */
   getTwilioClient(options?: TwilioClientOptions): twilio.Twilio;
+  /**
+   * The domain name for the Service that contains this Function.
+   */
   DOMAIN_NAME: string;
+  /**
+   * The path of this Function
+   */
   PATH: string;
+  /**
+   * The unique SID of the Service that contains this Function
+   */
   SERVICE_SID: string | undefined;
+  /**
+   * The unique SID of the Environment that this Function has been deployed to
+   */
   ENVIRONMENT_SID: string | undefined;
 } & T;
 

--- a/packages/serverless-runtime-types/types.d.ts
+++ b/packages/serverless-runtime-types/types.d.ts
@@ -137,7 +137,8 @@ export interface TwilioResponse {
    */
   setHeaders(headers: { [key: string]: string }): TwilioResponse;
   /**
-   * Add a cookie to the HTTP response. Accepts the name of the cookie, its value, and any optional attributes to be assigned to the cookie
+   * Add a cookie to the HTTP response.
+   * Accepts the name of the cookie, its value, and any optional attributes to be assigned to the cookie.
    *
    * @param key - The name of the cookie to be set
    * @param value - The value of the cookie
@@ -191,7 +192,17 @@ export type RuntimeSyncClientOptions = TwilioClientOptions & {
 };
 
 export type RuntimeSyncServiceContext = ServiceContext & {
+  /**
+   * Alias for `syncMaps`
+   *
+   * @see https://www.twilio.com/docs/sync/api/list-resource
+   */
   maps: SyncMapListInstance;
+  /**
+   * Alias for `syncLists`
+   *
+   * @see https://www.twilio.com/docs/sync/api/map-resource
+   */
   lists: SyncListListInstance;
 };
 
@@ -264,7 +275,7 @@ export type RuntimeInstance = {
    */
   getFunctions(): ResourceMap;
   /**
-   * Returns a Sync Service Context object that has been configured to work with your default Sync Service
+   * Returns a Sync Service Context object that has been configured to work with your default Sync Service.
    *
    * @param options - Optional object to configure the Sync Context, such as the name of a different Sync Service
    * @returns A Sync Context object for interacting with Twilio Sync

--- a/packages/serverless-runtime-types/types.d.ts
+++ b/packages/serverless-runtime-types/types.d.ts
@@ -22,11 +22,163 @@ export type AssetResourceMap = {
 };
 
 export interface TwilioResponse {
+  /**
+   * Set the status code of the response.
+   * @param code - Integer value of the status code
+   * @returns This Response object to enable method chaining
+   *
+   * @see https://www.twilio.com/docs/runtime/functions/invocation#twilio-response-methods
+   *
+   * Example usage of Response.setStatusCode():
+   * ```ts
+   * exports.handler = (context, event, callback) => {
+   *   const response = new Twilio.Response();
+   *   // Set the status code to 204 Not Content
+   *   response.setStatusCode(204);
+   *
+   *   return callback(null, response);
+   * };
+   * ```
+   *
+   */
   setStatusCode(code: number): TwilioResponse;
+  /**
+   * Set the body of the response. Takes either a string or an object.
+   * @param body - The body of the response
+   * @returns This Response object to enable method chaining
+   *
+   * @see https://www.twilio.com/docs/runtime/functions/invocation#twilio-response-methods
+   *
+   * Example usage of Response.setBody() with a string
+   * ```ts
+   * exports.handler = (context, event, callback) => {
+   *   const response = new Twilio.Response();
+   *   // Set the response body
+   *   response.setBody('Everything is fine');
+   *
+   *   return callback(null, response);
+   * };
+   * ```
+   *
+   * Example usage of Response.setBody() with an object
+   * ```ts
+   * exports.handler = (context, event, callback) => {
+   *   const response = new Twilio.Response();
+   *   // Set the response body
+   *   response.setBody({ everything: 'is fine' });
+   *
+   *   return callback(null, response);
+   * };
+   * ```
+   */
   setBody(body: string | object): TwilioResponse;
+  /**
+   * Adds a header to the HTTP response. The first argument specifies the header name and the second argument the header value.
+   *
+   * If Response.appendHeader is called with the name of a header that already exists on this Response object, that header will be converted from a string to an array, and the provided value will be concatenated to that array of values.
+   *
+   * @param key - The name of the header
+   * @param value - The value of the header
+   * @returns This Response object to enable method chaining
+   *
+   * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responseappendheaderkey-value
+   *
+   * Example usage of Response.appendHeader()
+   * ```ts
+   * exports.handler = (context, event, callback) => {
+   *   const response = new Twilio.Response();
+   *   response
+   *     .appendHeader('content-type', 'application/json')
+   *     // You can append a multi-value header by passing a list of strings
+   *     .appendHeader('yes', ['no', 'maybe', 'so'])
+   *     // Instead of setting the header to an array, it's also valid to
+   *     // pass a comma-separated string of values
+   *     .appendHeader('cache-control', 'no-store, max-age=0');
+   *     .appendHeader('never', 'gonna')
+   *     // Appending a header that already exists will convert that header to
+   *     // a multi-value header and concatenate the new value
+   *     .appendHeader('never', 'give')
+   *     .appendHeader('never', 'you')
+   *     .appendHeader('never', 'up');
+   *     // The header is now `'never': ['gonna', 'give', 'you', 'up']`
+   *
+   *   return callback(null, response);
+   * };
+   * ```
+   */
   appendHeader(key: string, value: string): TwilioResponse;
+  /**
+   * Set multiple headers on the HTTP response in one method call. Accepts an object of key-value pairs of headers and their corresponding values. You may also set multi-value headers by making the intended header an array.
+   *
+   * @param headers - An object of headers to append to the response. Can include set-cookie
+   * @returns This Response object to enable method chaining
+   *
+   * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responsesetheadersheaders
+   *
+   * Example usage of Response.setHeaders()
+   * ```ts
+   * exports.handler = (context, event, callback) => {
+   *   const response = new Twilio.Response();
+   *   response.setHeaders({
+   *     // Set a single header
+   *     'content-type': 'application/json',
+   *     // You can set a header with multiple values by providing an array
+   *     'cache-control': ['no-cache', 'private'],
+   *     // You may also optionally set cookies via the "Set-Cookie" key
+   *     'set-cookie': 'Foo=Bar',
+   *   });
+   *
+   *   return callback(null, response);
+   * };
+   * ```
+   */
   setHeaders(headers: { [key: string]: string }): TwilioResponse;
+  /**
+   * Add a cookie to the HTTP response. Accepts the name of the cookie, its value, and any optional attributes to be assigned to the cookie
+   *
+   * @param key - The name of the cookie to be set
+   * @param value - The value of the cookie
+   * @param attributes - Optional attributes to assign to the cookie
+   * @returns This Response object to enable method chaining
+   *
+   * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responsesetcookiekey-value-attributes
+   *
+   * Example usage of Response.setCookie()
+   * ```ts
+   * exports.handler = (context, event, callback) => {
+   *   const response = new Twilio.Response();
+   *   response
+   *     .setCookie('has_recent_activity', 'true')
+   *     .setCookie('tz', 'America/Los_Angeles', [
+   *       'HttpOnly',
+   *       'Secure',
+   *       'SameSite=Strict',
+   *       'Max-Age=86400',
+   *     ]);
+   *
+   *   return callback(null, response);
+   * };
+   * ```
+   */
   setCookie(key: string, value: string, attributes?: string[]): TwilioResponse;
+  /**
+   * Effectively remove a specific cookie from the HTTP response. Accepts the name of the cookie to be removed, and sets the Max-Age attribute of the cookie equal to 0 so that clients and browsers will remove the cookie upon receiving the response.
+   *
+   * @param key - The name of the cookie to be removed
+   * @returns This Response object to enable method chaining
+   *
+   * @see https://www.twilio.com/docs/runtime/functions/headers-and-cookies/setting-and-modifying#responseremovecookiekey
+   *
+   * Example usage of Response.removeCookie()
+   * ```ts
+   * exports.handler = (context, event, callback) => {
+   *   const response = new Twilio.Response();
+   *   response.removeCookie('tz');
+   *
+   *   return callback(null, response);
+   * };
+   * ```
+   */
   removeCookie(key: string): TwilioResponse;
 }
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Closes https://issues.corp.twilio.com/browse/DEVED-6473 by adding TSDoc comments to describe params and return values for methods, as well as inline examples as in other [libraries](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1129).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
