### PR TITLE
feat(twilio-run): add default runtime for config file

### DIFF
--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -36,7 +36,7 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"production\\": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,
 	// \\"properties\\": null 	/* Specify the output properties you want to see. Works best on single types */,
 	// \\"region\\": null 	/* Twilio API Region */,
-	// \\"runtime\\": null 	/* The version of Node.js to deploy the build to. (node12 or node14) */,
+	\\"runtime\\": \\"node12\\" 	/* The version of Node.js to deploy the build to. (node12 or node14) */,
 	// \\"serviceName\\": null 	/* Overrides the name of the Serverless project. Default: the name field in your package.json */,
 	// \\"serviceSid\\": null 	/* SID of the Twilio Serverless Service to deploy to */,
 	// \\"sourceEnvironment\\": null 	/* SID or suffix of an existing environment you want to deploy from. */,

--- a/packages/twilio-run/src/templating/defaultConfig.ts
+++ b/packages/twilio-run/src/templating/defaultConfig.ts
@@ -9,6 +9,8 @@ import { getDebugFunction } from '../utils/logger';
 
 const debug = getDebugFunction('twilio-run:templating:defaultConfig');
 
+const DEFAULT_RUNTIME = 'node12';
+
 function renderDefault(config: Options): string {
   if (config.type === 'boolean') {
     if (typeof config.default === 'boolean') {
@@ -26,6 +28,13 @@ function renderDefault(config: Options): string {
 }
 
 function templateFlagAsConfig([flag, config]: [string, Options]) {
+  if (flag === 'runtime' && typeof config.default !== 'string') {
+    // special case for runtime with a hard coded default for a better Node.js transition
+    return `\t"${camelCase(flag)}": "${DEFAULT_RUNTIME}" \t/* ${
+      config.describe
+    } */,`;
+  }
+
   return `\t// "${camelCase(flag)}": ${renderDefault(config)} \t/* ${
     config.describe
   } */,`;


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
