### PR TITLE
Node 14 default

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -6,7 +6,7 @@ module.exports = {
     '@twilio/runtime-handler'
   ].replace(/[\^~]/, ''),
   twilioRun: pkgJson.dependencies['twilio-run'],
-  node: '12',
+  node: '14',
   typescript: '^3.8',
   serverlessRuntimeTypes: '^1.1',
   copyfiles: '^2.2.0',

--- a/packages/plugin-serverless/README.md
+++ b/packages/plugin-serverless/README.md
@@ -122,7 +122,7 @@ OPTIONS
   --production                         Please prefer the "activate" command! Deploys to the production environment (no
                                        domain suffix). Overrides the value passed via the environment flag.
 
-  --runtime=runtime                    The version of Node.js to deploy the build to. (node12 or node14)
+  --runtime=runtime                    The version of Node.js to deploy the build to. (node14)
 
   --service-sid=service-sid            SID of the Twilio Serverless Service to deploy to
 

--- a/packages/serverless-api/examples/deploy.js
+++ b/packages/serverless-api/examples/deploy.js
@@ -10,7 +10,7 @@ async function run() {
   const result = await client.deployProject({
     ...config,
     overrideExistingService: true,
-    runtime: 'node12',
+    runtime: 'node14',
     env: {
       HELLO: 'ahoy',
       WORLD: 'welt',

--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -44,7 +44,7 @@ type DeployProjectConfigBase = {
    */
   overrideExistingService?: boolean;
   /**
-   * Version of Node.js to deploy with in Twilio Runtime. Can be "node12" or "node14"
+   * Version of Node.js to deploy with in Twilio Runtime. Can be "node14"
    */
   runtime?: string;
 };

--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -36,7 +36,7 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"production\\": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,
 	// \\"properties\\": null 	/* Specify the output properties you want to see. Works best on single types */,
 	// \\"region\\": null 	/* Twilio API Region */,
-	\\"runtime\\": \\"node12\\" 	/* The version of Node.js to deploy the build to. (node12 or node14) */,
+	\\"runtime\\": \\"node14\\" 	/* The version of Node.js to deploy the build to. (node14) */,
 	// \\"serviceName\\": null 	/* Overrides the name of the Serverless project. Default: the name field in your package.json */,
 	// \\"serviceSid\\": null 	/* SID of the Twilio Serverless Service to deploy to */,
 	// \\"sourceEnvironment\\": null 	/* SID or suffix of an existing environment you want to deploy from. */,

--- a/packages/twilio-run/src/checks/nodejs-version.ts
+++ b/packages/twilio-run/src/checks/nodejs-version.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 import { logger } from '../utils/logger';
 
-const SERVERLESS_NODE_JS_VERSION = '12.';
+const SERVERLESS_NODE_JS_VERSION = '14.';
 
 export function printVersionWarning(
   nodeVersion: string,

--- a/packages/twilio-run/src/flags.ts
+++ b/packages/twilio-run/src/flags.ts
@@ -228,8 +228,7 @@ export const ALL_FLAGS = {
   } as Options,
   runtime: {
     type: 'string',
-    describe:
-      'The version of Node.js to deploy the build to. (node12 or node14)',
+    describe: 'The version of Node.js to deploy the build to. (node14)',
   } as Options,
   key: {
     type: 'string',

--- a/packages/twilio-run/src/templating/defaultConfig.ts
+++ b/packages/twilio-run/src/templating/defaultConfig.ts
@@ -9,7 +9,7 @@ import { getDebugFunction } from '../utils/logger';
 
 const debug = getDebugFunction('twilio-run:templating:defaultConfig');
 
-const DEFAULT_RUNTIME = 'node12';
+const DEFAULT_RUNTIME = 'node14';
 
 function renderDefault(config: Options): string {
   if (config.type === 'boolean') {


### PR DESCRIPTION
Node 12 is going away at the end of April. This updates the default Node version for new projects created with `create-twilio-function` to 14.

It also changes some documentation throughout the packages to refer to Node 14 and remove mentions of Node 12.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
