### PR TITLE
[Security ] twilio 3.29.* to 3.71.*

### DIFF
--- a/packages/runtime-handler/package.json
+++ b/packages/runtime-handler/package.json
@@ -73,7 +73,7 @@
     "nocache": "^2.1.0",
     "normalize.css": "^8.0.1",
     "serialize-error": "^7.0.1",
-    "twilio": "3.29.2"
+    "twilio": "^3.71.2"
   },
   "gitHead": "6db273648ed19474f4125042556b10c051529912"
 }


### PR DESCRIPTION
Twilio 3.29 package includes an insecure version of `moment.js` 
https://github.com/advisories/GHSA-8hfj-j24r-96c4

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
