### PR TITLE
fix(create-twilio-function): handle rimraf failing

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function.js
+++ b/packages/create-twilio-function/src/create-twilio-function.js
@@ -31,9 +31,16 @@ const successMessage = require('./create-twilio-function/success-message');
 async function cleanUpAndExit(projectDir, spinner, errorMessage) {
   spinner.fail(errorMessage);
   spinner.start('Cleaning up project directories and files');
-  await rimraf(projectDir);
-  spinner.stop().clear();
-  process.exitCode = 1;
+  try {
+    await rimraf(projectDir);
+  } catch (error) {
+    spinner.fail(
+      `There was an error cleaning up the project. Some files may still be present in ${projectDir}`
+    );
+  } finally {
+    spinner.stop().clear();
+    process.exitCode = 1;
+  }
 }
 
 async function performTaskWithSpinner(spinner, message, task) {


### PR DESCRIPTION
Received a report that creating a new project had failed for a developer
and then the cleanup task didn't end. There was an issue with deleting
the files that had been created which threw an unhandled error in the
`cleanUpAndExit` function leading to the spinner never stopping.

This adds a `try`/`catch`/`finally` around `rimraf` in `cleanUpAndExit` to ensure
that it does indeed exit.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
