### PR TITLE
chore(deps): upgrades typescript to 4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.0",
-    "typescript": "^3.9.7"
+    "typescript": "^4.2.4"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/packages/runtime-handler/package.json
+++ b/packages/runtime-handler/package.json
@@ -55,7 +55,7 @@
     "rimraf": "^2.6.3",
     "supertest": "^3.1.0",
     "ts-jest": "^26.5.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.2.4"
   },
   "bugs": {
     "url": "https://github.com/twilio-labs/serverless-toolkit/issues"

--- a/packages/serverless-api/package.json
+++ b/packages/serverless-api/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "^26.5.0",
     "typedoc": "^0.19.2",
     "typedoc-plugin-external-module-name": "^4.0.6",
-    "typescript": "^3.8.3"
+    "typescript": "^4.2.4"
   },
   "dependencies": {
     "@types/mime-types": "^2.1.0",

--- a/packages/twilio-run/package.json
+++ b/packages/twilio-run/package.json
@@ -113,7 +113,7 @@
     "mock-fs": "^4.12.0",
     "nock": "^12.0.2",
     "supertest": "^3.1.0",
-    "typescript": "^3.9.2"
+    "typescript": "^4.2.4"
   },
   "files": [
     "bin/",

--- a/packages/twilio-run/src/printers/deploy.ts
+++ b/packages/twilio-run/src/printers/deploy.ts
@@ -103,12 +103,23 @@ ${serviceInfo}
   );
 }
 
+type PrintObject = {
+  account: string;
+  serviceName?: string;
+  serviceSid?: string;
+  environment: string;
+  rootDirectory: string;
+  dependencies: string;
+  environmentVariables: string;
+  runtime?: string;
+};
+
 function plainPrintConfigInfo(config: DeployLocalProjectConfig) {
   let dependencyString = '';
   if (config.pkgJson && config.pkgJson.dependencies) {
     dependencyString = Object.keys(config.pkgJson.dependencies).join(',');
   }
-  const printObj = {
+  const printObj: PrintObject = {
     account: config.username,
     serviceName: config.serviceName,
     serviceSid: config.serviceSid,


### PR DESCRIPTION
Fixes one type issue that came up in the upgrade. The project builds now.

4.2.4 is not the latest version of TS for now. Reports around the internet showed that upgrading to TS 4.2 fixed the Prettier issues we've been seeing. Upgrading all the way to 4.7.x caused a bunch more type issues. We should plan an upgrade, in order to keep up, but there might be further effects.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
