### PR TITLE
chore: [RUN-4878] Add Node16 support

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -6,7 +6,7 @@ module.exports = {
     '@twilio/runtime-handler'
   ].replace(/[\^~]/, ''),
   twilioRun: pkgJson.dependencies['twilio-run'],
-  node: '14',
+  node: '16',
   typescript: '^3.8',
   serverlessRuntimeTypes: '^1.1',
   copyfiles: '^2.2.0',

--- a/packages/plugin-serverless/README.md
+++ b/packages/plugin-serverless/README.md
@@ -157,7 +157,7 @@ FLAGS
   --password=<value>               A specific API secret or auth token for deployment. Uses fields from .env otherwise
   --production                     Please prefer the "activate" command! Deploys to the production environment (no
                                    domain suffix). Overrides the value passed via the environment flag.
-  --runtime=<value>                The version of Node.js to deploy the build to. (node14)
+  --runtime=<value>                The version of Node.js to deploy the build to. (node16)
   --service-sid=<value>            SID of the Twilio Serverless Service to deploy to
   --silent                         Suppress  output and logs. This is a shorthand for "-l none -o none".
   --to=<value>                     [Alias for "environment"]

--- a/packages/serverless-api/examples/deploy.js
+++ b/packages/serverless-api/examples/deploy.js
@@ -10,7 +10,7 @@ async function run() {
   const result = await client.deployProject({
     ...config,
     overrideExistingService: true,
-    runtime: 'node14',
+    runtime: 'node16',
     env: {
       HELLO: 'ahoy',
       WORLD: 'welt',

--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -44,7 +44,7 @@ type DeployProjectConfigBase = {
    */
   overrideExistingService?: boolean;
   /**
-   * Version of Node.js to deploy with in Twilio Runtime. Can be "node14"
+   * Version of Node.js to deploy with in Twilio Runtime. Can be "node16"
    */
   runtime?: string;
 };

--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -36,7 +36,7 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"production\\": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,
 	// \\"properties\\": null 	/* Specify the output properties you want to see. Works best on single types */,
 	// \\"region\\": null 	/* Twilio API Region */,
-	\\"runtime\\": \\"node14\\" 	/* The version of Node.js to deploy the build to. (node14) */,
+	\\"runtime\\": \\"node16\\" 	/* The version of Node.js to deploy the build to. (node16) */,
 	// \\"serviceName\\": null 	/* Overrides the name of the Serverless project. Default: the name field in your package.json */,
 	// \\"serviceSid\\": null 	/* SID of the Twilio Serverless Service to deploy to */,
 	// \\"sourceEnvironment\\": null 	/* SID or suffix of an existing environment you want to deploy from. */,

--- a/packages/twilio-run/src/checks/nodejs-version.ts
+++ b/packages/twilio-run/src/checks/nodejs-version.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 import { logger } from '../utils/logger';
 
-const SERVERLESS_NODE_JS_VERSION = '14.';
+const SERVERLESS_NODE_JS_VERSION = '16.';
 
 export function printVersionWarning(
   nodeVersion: string,

--- a/packages/twilio-run/src/checks/nodejs-version.ts
+++ b/packages/twilio-run/src/checks/nodejs-version.ts
@@ -1,11 +1,11 @@
 import { stripIndent } from 'common-tags';
 import { logger } from '../utils/logger';
 
-const SERVERLESS_NODE_JS_VERSION = '16.';
+const SERVERLESS_NODE_JS_VERSION = ['14.', '16.'];
 
 export function printVersionWarning(
   nodeVersion: string,
-  expectedVersion: string
+  expectedVersion: string[]
 ): void {
   const title = 'Different Node.js Version Found';
   const msg = stripIndent`
@@ -22,7 +22,11 @@ export function printVersionWarning(
 
 export default function checkNodejsVersion() {
   const nodeVersion = process.versions.node;
-  if (!nodeVersion.startsWith(SERVERLESS_NODE_JS_VERSION)) {
+  if (
+    !SERVERLESS_NODE_JS_VERSION.some((nodeJsVersion) =>
+      nodeVersion.startsWith(nodeJsVersion)
+    )
+  ) {
     printVersionWarning(nodeVersion, SERVERLESS_NODE_JS_VERSION);
   }
 }

--- a/packages/twilio-run/src/flags.ts
+++ b/packages/twilio-run/src/flags.ts
@@ -228,7 +228,7 @@ export const ALL_FLAGS = {
   } as Options,
   runtime: {
     type: 'string',
-    describe: 'The version of Node.js to deploy the build to. (node14)',
+    describe: 'The version of Node.js to deploy the build to. (node16)',
   } as Options,
   key: {
     type: 'string',

--- a/packages/twilio-run/src/templating/defaultConfig.ts
+++ b/packages/twilio-run/src/templating/defaultConfig.ts
@@ -9,7 +9,7 @@ import { getDebugFunction } from '../utils/logger';
 
 const debug = getDebugFunction('twilio-run:templating:defaultConfig');
 
-const DEFAULT_RUNTIME = 'node14';
+const DEFAULT_RUNTIME = 'node16';
 
 function renderDefault(config: Options): string {
   if (config.type === 'boolean') {


### PR DESCRIPTION
## Description

JIRA Ticket: https://issues.corp.twilio.com/browse/RUN-4878

- Adding support for Node16 Runtime

## Testing
Follow [this doc](https://docs.google.com/document/d/1bCnR-b-TR9VKhajnxYlJ3G5q0ckwldeSZSwYbb0IBEE/edit) to setup Serverless toolkit

Updated Twilio Serverless Plugin to point to my local
```
➜  plugin-serverless git:(RUN-4876-Serverless-Node16) twilio plugins:link .
twilio-cli: linking plugin @twilio-labs/plugin-serverless... done

➜  plugin-serverless git:(RUN-4876-Serverless-Node16) twilio plugins
@twilio-labs/plugin-serverless 3.0.4 (link) /Users/pthirumurthi/code/Projects/serverless/serverless-toolkit/packages/plugin-serverless
```
### Node 18 Warning
Added a debug log to print the Node version. **This warning doesn't appear for v14 and v16.**

```
test-node18-toolkit % twilio plugins
@twilio-labs/plugin-serverless 3.0.4 (link) /Users/pragad/Pragad/Twilio/ServerlessToolkit/serverless-toolkit/packages/plugin-serverless

test-node18-toolkit % nvm current
v18.12.1

test-node18-toolkit % twilio serverless:start
PRAGAD 1. nodeVersion: 18.12.1

│ WARNING Different Node.js Version Found
│
│ You are currently running Node.js 18.12.1 on this local machine. The production environment for Twilio Serverless currently supports versions 14.,16.x.
│
│ When you deploy to Twilio Serverless, you may encounter differences between local development and production.
│
│ For a more accurate local development experience, please switch your Node.js version.
│ A tool like nvm (https://github.com/creationix/nvm) can help.
```

### Node 16
Created a deployment and verified that `node16` is being used
```
test-node16-toolkit twilio serverless:deploy --override-existing-project

Deploying functions & assets to the Twilio Runtime

Username	SK6cf05c5a49b4101137f2ad05292d6dc5
Password	HfAO****************************
Service Name	test-node16-toolkit
Environment	dev
Root Directory	/Users/pthirumurthi/Pragad/Twilio/Serverless/Toolkit/test-node16-toolkit
Dependencies	twilio, @twilio/runtime-handler
Env Variables
Runtime		node16

✔ Serverless project successfully deployed

Deployment Details
Domain: test-node16-toolkit-9479-dev.dev.twil.io
Service:
   test-node16-toolkit (ZS3047dabd47c45aa5d2348e5600a4d872)
Environment:
   dev (ZE0962a3d3e42f3111fdfd9139b4c08f98)
Build SID:
   ZBdbf5e94036b21ae40c52f836b721110d
Runtime:
   node16
View Live Logs:
   Open the Twilio Console
Functions:
   [protected] https://test-node16-toolkit-9479-dev.dev.twil.io/sms/reply
   https://test-node16-toolkit-9479-dev.dev.twil.io/hello-world
   https://test-node16-toolkit-9479-dev.dev.twil.io/private-message
Assets:
   [private] Runtime.getAssets()['/message.js']
   https://test-node16-toolkit-9479-dev.dev.twil.io/index.html
   https://test-node16-toolkit-9479-dev.dev.twil.io/style.css
```

Packager logs for the above request
```
[2022-11-08T13:21:08.100-08:00] - INFO  - c.t.s.s.a.Dequeuer -  - [1165390e-68a2-4e4e-aa95-387cbbd4d3f1] [e2d288adc8e27fa987fd1fc5ddb63ece] New build request: {"manifestSid":null,"deploymentSid":null,"retry_attempts":0,"build_sid":"ZBdbf5e94036b21ae40c52f836b721110d","account_sid":"AC42667b466a342f0604c3b1072bb8d25b","request_sid":"RQd59796df3d62ed0abbf3381189983194","service_sid":"ZS3047dabd47c45aa5d2348e5600a4d872","packager_account_sid":"AC7d36f8dd1a7a706a8474eebd39c98324","packager_service_sid":"ZS42353afe0e5e75955044b93356add049","packager_domain_name":"packager-node16-v1-5223-227981179943781.dev.twil.io","packaging_method":"SANDBOXED","runtime":"node16","origin_region":"dev-us1"}
```

### Node 14

Successful deployment 
```
➜  test-node16-toolkit twilio serverless:deploy --runtime=node14 --override-existing-project


Deploying functions & assets to the Twilio Runtime

Username	SK6cf05c5a49b4101137f2ad05292d6dc5
Password	HfAO****************************
Service SID	ZS3047dabd47c45aa5d2348e5600a4d872
Environment	dev
Root Directory	/Users/pthirumurthi/Pragad/Twilio/Serverless/Toolkit/test-node16-toolkit
Dependencies	twilio, @twilio/runtime-handler
Env Variables
Runtime		node14

✔ Serverless project successfully deployed

Deployment Details
Domain: test-node16-toolkit-9479-dev.dev.twil.io
Service:
   test-node16-toolkit (ZS3047dabd47c45aa5d2348e5600a4d872)
Environment:
   dev (ZE0962a3d3e42f3111fdfd9139b4c08f98)
Build SID:
   ZBe7bb9d073869aacde0e24fce5144d30b
Runtime:
   node14
View Live Logs:
   Open the Twilio Console
Functions:
   [protected] https://test-node16-toolkit-9479-dev.dev.twil.io/sms/reply
   https://test-node16-toolkit-9479-dev.dev.twil.io/hello-world
   https://test-node16-toolkit-9479-dev.dev.twil.io/private-message
Assets:
   [private] Runtime.getAssets()['/message.js']
   https://test-node16-toolkit-9479-dev.dev.twil.io/index.html
   https://test-node16-toolkit-9479-dev.dev.twil.io/style.css
```

Packager logs 
```
[2022-11-08T17:07:52.244-08:00] - INFO  - c.t.s.s.a.Dequeuer -  - [cb498138-d353-4b3f-8491-d20d9f8646dc] [1c4bd34218138f091a89d572c2621a19] New build request: {"manifestSid":null,"deploymentSid":null,"retry_attempts":0,"build_sid":"ZBe7bb9d073869aacde0e24fce5144d30b","account_sid":"AC42667b466a342f0604c3b1072bb8d25b","request_sid":"RQc0a159b3fd061db93760517d3458891e","service_sid":"ZS3047dabd47c45aa5d2348e5600a4d872","packager_account_sid":"AC7d36f8dd1a7a706a8474eebd39c98324","packager_service_sid":"ZS88b3d4637d36ef3fff7d35ee0f3c7547","packager_domain_name":"packager-node14-v1-8663-295131147494397.dev.twil.io","packaging_method":"SANDBOXED","runtime":"node14","origin_region":"dev-us1"}
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
