### PR TITLE
fix(twilio-run): lookup of deployinfo if no region is specified

### DIFF
--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -68,6 +68,7 @@ function normalizeFlags(flags, aliasMap, argv) {
   const [, command, ...args] = argv;
   result.$0 = path.basename(command);
   result._ = args;
+  result.logLevel = result['cli-log-level'];
 
   return result;
 }

--- a/packages/twilio-run/src/serverless-api/utils.ts
+++ b/packages/twilio-run/src/serverless-api/utils.ts
@@ -23,7 +23,7 @@ export async function getFunctionServiceSid(
   configName: string,
   commandConfig: 'deploy' | 'list' | 'logs' | 'promote' | 'env',
   username?: string,
-  region?: string
+  region: string = 'us1'
 ): Promise<string | undefined> {
   const twilioConfig = readSpecializedConfig(cwd, configName, commandConfig, {
     username,


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
