### PR TITLE
fix(plugin-serverless): fix output issue with start command

### DIFF
--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -68,7 +68,9 @@ function normalizeFlags(flags, aliasMap, argv) {
   const [, command, ...args] = argv;
   result.$0 = path.basename(command);
   result._ = args;
-  result.logLevel = result['cli-log-level'];
+  if (result['cli-log-level']) {
+    result.logLevel = result['cli-log-level'];
+  }
 
   return result;
 }

--- a/packages/plugin-serverless/tests/utils.test.js
+++ b/packages/plugin-serverless/tests/utils.test.js
@@ -65,6 +65,41 @@ describe('normalizeFlags', () => {
       environment: 'prod',
     });
   });
+
+  test('overrides log-level with cli-log-level if present', () => {
+    const input = {
+      'log-level': 'info',
+      'cli-log-level': 'debug',
+      environment: 'prod',
+    };
+    const aliasMap = new Map();
+
+    const output = normalizeFlags(input, aliasMap, baseArgv);
+    expect(output).toEqual({
+      ...baseOutput,
+      'log-level': 'info',
+      'cli-log-level': 'debug',
+      cliLogLevel: 'debug',
+      logLevel: 'debug',
+      environment: 'prod',
+    });
+  });
+
+  test('uses regular log-level if no cli-log-level is present', () => {
+    const input = {
+      'log-level': 'debug',
+      environment: 'prod',
+    };
+    const aliasMap = new Map();
+
+    const output = normalizeFlags(input, aliasMap, baseArgv);
+    expect(output).toEqual({
+      ...baseOutput,
+      'log-level': 'debug',
+      logLevel: 'debug',
+      environment: 'prod',
+    });
+  });
 });
 
 describe('convertYargsOptionsToOclifFlags', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Fixes #442.

Since the `start` command inherits from the generic `Command` class from oclif and not from a `@twilio/cli-core` it uses `log-level` as flag and not `cli-log-level` so the change in #441 overrode it with `undefined` which resulted in no output. 

This change makes sure that the override only happens if cli-log-level is actually populated otherwise it falls back to regular log-level.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
