### PR TITLE
Fix test suite under Node 16

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: [14]
+        node-version: [14, 16]
 
     steps:
       - uses: actions/checkout@v1

--- a/packages/create-twilio-function/tests/create-gitignore.test.js
+++ b/packages/create-twilio-function/tests/create-gitignore.test.js
@@ -67,12 +67,14 @@ describe('create-gitignore', () => {
       const basePath = path.join(scratchDir, name);
       fs.mkdirSync(basePath, { recursive: true });
 
-      fs.closeSync(fs.openSync(path.join(basePath, '.gitignore'), 'w'));
-      expect.assertions(1);
+      const gitignorePath = path.join(basePath, '.gitignore');
+      fs.closeSync(fs.openSync(gitignorePath, 'w'));
+      expect.assertions(2);
       try {
         await createGitignore(basePath);
       } catch (e) {
-        expect(e.toString()).toMatch('file already exists');
+        expect(e.toString()).toMatch('Error');
+        expect(fs.readFileSync(gitignorePath, 'utf-8')).toEqual('');
       }
       cleanUp();
     });

--- a/packages/twilio-run/__tests__/templating/filesystem.test.ts
+++ b/packages/twilio-run/__tests__/templating/filesystem.test.ts
@@ -261,9 +261,11 @@ test('installation without dot-env file causes unexpected crash', async () => {
     "Cannot read property 'newEnvironmentVariableKeys' of undefined"
   );
 
-  await expect(
-    writeFiles([], './testing/', 'example', 'hello')
-  ).rejects.toThrowError(expected);
+  try {
+    await writeFiles([], './testing/', 'example', 'hello');
+  } catch (error) {
+    expect(error.toString()).toMatch('TypeError: Cannot read');
+  }
 });
 
 test('installation with an empty dependency file', async () => {

--- a/packages/twilio-run/package.json
+++ b/packages/twilio-run/package.json
@@ -111,7 +111,7 @@
     "@types/window-size": "^0.2.4",
     "cheerio": "^1.0.0-rc.2",
     "listr-silent-renderer": "^1.1.1",
-    "mock-fs": "^4.12.0",
+    "mock-fs": "^5.2.0",
     "nock": "^12.0.2",
     "supertest": "^3.1.0",
     "typescript": "^3.9.2"


### PR DESCRIPTION
<!-- Describe your Pull Request -->
The test suite wasn't working on Node.js 16 for a couple of issues between the two version. Namely:
1. The error message for accessing an undefined property has changed
2. The error that gets triggered when `createWriteStream` is being called on a file that already exists is triggered later which results in another function call to issue it's error message first. This is technically a bug in Node.js but in the meantime I updated the test to be functionally checking that everything worked accordingly instead
3. One test was failing because the `mock-fs` dependency version wasn't working under Node 16 so I updated it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
