### PR TITLE
fix(twilio-run): remove key/value check from env:import command

### DIFF
--- a/packages/twilio-run/src/config/env/env-import.ts
+++ b/packages/twilio-run/src/config/env/env-import.ts
@@ -79,18 +79,6 @@ export async function getConfigFromFlags(
 
   let serviceName = await getServiceNameFromFlags(flags);
 
-  if (!flags.key) {
-    throw new Error(
-      'Missing --key argument. Please provide a key for your environment variable.'
-    );
-  }
-
-  if (!flags.value) {
-    throw new Error(
-      'Missing --value argument. Please provide a key for your environment variable.'
-    );
-  }
-
   const env = filterEnvVariablesForDeploy(envFileVars);
 
   return {


### PR DESCRIPTION
<!-- Describe your Pull Request -->
The `serverless:env:import` command wasn't working as expected because we had a check for `key` and `value` which aren't actually required. This appears to be a copy & paste mistake because those two flags aren't even used in the code.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
