### PR TITLE
docs(serverless-api): fix serverless-api docs build

### DIFF
--- a/packages/serverless-api/package.json
+++ b/packages/serverless-api/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "build:noemit": "tsc --noEmit",
-    "docs": "echo 'fix typedoc --options typedoc.json'; exit 1;",
+    "docs": "typedoc --options typedoc.json",
     "clean": "rimraf ./dist",
     "prepack": "run-s clean build"
   },

--- a/packages/serverless-api/typedoc.json
+++ b/packages/serverless-api/typedoc.json
@@ -1,9 +1,10 @@
 {
   "name": "@twilio-labs/serverless-api",
-  "mode": "modules",
+  "entryPoints": ["src/index.ts"],
   "out": "docs",
   "theme": "default",
   "exclude": ["**/__tests__/*.ts"],
-  "gaID": "UA-40008341-3",
-  "excludeNotExported": true
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "gaID": "UA-40008341-3"
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Re-enabling typedoc after adjusting the config for typedoc to work again.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
