### PR TITLE
feat(create-twilio-function): bump default versions for typescript projects

### DIFF
--- a/.changeset/quiet-sheep-clap.md
+++ b/.changeset/quiet-sheep-clap.md
@@ -1,0 +1,6 @@
+---
+'create-twilio-function': minor
+'@twilio-labs/plugin-serverless': minor
+---
+
+Use TypeScript 4.9 for new TypeScript projects

--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -7,7 +7,7 @@ module.exports = {
   ].replace(/[\^~]/, ''),
   twilioRun: pkgJson.dependencies['twilio-run'],
   node: '16',
-  typescript: '^3.8',
+  typescript: '^4.9',
   serverlessRuntimeTypes: '^1.1',
-  copyfiles: '^2.2.0',
+  copyfiles: '^2.4.1',
 };


### PR DESCRIPTION
Fixes #464 by bumping the TypeScript default version

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
