### PR TITLE
feat(twilio-run): upgrading serverless-runtime-types

### DIFF
--- a/.changeset/nervous-dingos-ring.md
+++ b/.changeset/nervous-dingos-ring.md
@@ -1,0 +1,5 @@
+---
+'twilio-run': minor
+---
+
+Upgraded serverless-runtime-types package and fixed typing errors that arose

--- a/packages/twilio-run/package.json
+++ b/packages/twilio-run/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@twilio-labs/serverless-api": "^5.5.0",
-    "@twilio-labs/serverless-runtime-types": "2.1.0-rc.0",
+    "@twilio-labs/serverless-runtime-types": "^2.2.3",
     "@types/express": "4.17.7",
     "@types/inquirer": "^6.0.3",
     "@types/is-ci": "^2.0.0",

--- a/packages/twilio-run/src/runtime/internal/response.ts
+++ b/packages/twilio-run/src/runtime/internal/response.ts
@@ -57,6 +57,18 @@ export class Response implements TwilioResponse {
     return this;
   }
 
+  setCookie(
+    key: string,
+    value: string,
+    attributes?: string[] | undefined
+  ): Response {
+    return this;
+  }
+
+  removeCookie(key: string): Response {
+    return this;
+  }
+
   appendHeader(key: string, value: HeaderValue): Response {
     debug('Appending header for %s', key, value);
     this.headers = this.headers || {};

--- a/packages/twilio-run/src/runtime/internal/response.ts
+++ b/packages/twilio-run/src/runtime/internal/response.ts
@@ -15,15 +15,25 @@ type Headers = {
   [key: string]: HeaderValue;
 };
 
+type CookieValue = {
+  value: string;
+  attributes?: string[] | undefined;
+};
+type Cookies = {
+  [key: string]: CookieValue;
+};
+
 export class Response implements TwilioResponse {
   private body: null | any;
   private statusCode: number;
   private headers: Headers;
+  private cookies: Cookies;
 
   constructor(options?: ResponseOptions) {
     this.body = null;
     this.statusCode = 200;
     this.headers = {};
+    this.cookies = {};
 
     if (options && options.statusCode) {
       this.statusCode = options.statusCode;
@@ -62,10 +72,14 @@ export class Response implements TwilioResponse {
     value: string,
     attributes?: string[] | undefined
   ): Response {
+    debug('Setting cookie %s', key, value, attributes);
+    this.cookies[key] = { value, attributes };
     return this;
   }
 
   removeCookie(key: string): Response {
+    debug('Deleting cookie %s', key);
+    delete this.cookies[key];
     return this;
   }
 

--- a/packages/twilio-run/src/runtime/route.ts
+++ b/packages/twilio-run/src/runtime/route.ts
@@ -1,6 +1,7 @@
 import {
   Context,
   ServerlessCallback,
+  ServerlessEventObject,
   ServerlessFunctionSignature,
 } from '@twilio-labs/serverless-runtime-types/types';
 import { fork } from 'child_process';
@@ -62,7 +63,14 @@ export function constructContext<T extends {} = {}>(
   }
   const DOMAIN_NAME = url.replace(/^https?:\/\//, '');
   const PATH = functionPath;
-  return { PATH, DOMAIN_NAME, ...env, getTwilioClient };
+  return {
+    PATH,
+    DOMAIN_NAME,
+    ...env,
+    getTwilioClient,
+    SERVICE_SID: env.SERVICE_SID,
+    ENVIRONMENT_SID: env.ENVIRONMENT_SID,
+  };
 }
 
 export function constructGlobalScope(config: StartCliConfig): void {
@@ -205,7 +213,7 @@ export function functionToRoute(
     res: ExpressResponse,
     next: NextFunction
   ) {
-    const event = constructEvent(req);
+    const event = constructEvent<ServerlessEventObject>(req);
     debug('Event for %s: %o', req.path, event);
     const context = constructContext(config, req.path);
     debug('Context for %s: %p', req.path, context);


### PR DESCRIPTION
<!-- Describe your Pull Request -->

- Upgraded `serverless-runtime-types` in the `twilio-run` package
- Fixed typing errors that arose from using the new version
  - Added cookies attribute to `Response` class, as well as `setCookie` and `removeCookie` functions in order to fully implement the `TwilioResponse` interface
  - in the `constructContext` function of routes.ts, I had to explicitly include the `SERVICE_SID` and `ENVIRONMENT_SID` attributes of `env` due to `env` being typed as `any`
  - I had to specify `ServerlessEventObject` as the type parameter for an invocation of `constructContext`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
