### PR TITLE
FRIDGE-9: Update toolkit to default to node18

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -6,7 +6,7 @@ module.exports = {
     '@twilio/runtime-handler'
   ].replace(/[\^~]/, ''),
   twilioRun: pkgJson.dependencies['twilio-run'],
-  node: '16',
+  node: '18',
   typescript: '^3.8',
   serverlessRuntimeTypes: '^1.1',
   copyfiles: '^2.2.0',

--- a/packages/plugin-serverless/README.md
+++ b/packages/plugin-serverless/README.md
@@ -157,7 +157,7 @@ FLAGS
   --password=<value>               A specific API secret or auth token for deployment. Uses fields from .env otherwise
   --production                     Please prefer the "activate" command! Deploys to the production environment (no
                                    domain suffix). Overrides the value passed via the environment flag.
-  --runtime=<value>                The version of Node.js to deploy the build to. (node16)
+  --runtime=<value>                The version of Node.js to deploy the build to. (node18)
   --service-sid=<value>            SID of the Twilio Serverless Service to deploy to
   --silent                         Suppress  output and logs. This is a shorthand for "-l none -o none".
   --to=<value>                     [Alias for "environment"]

--- a/packages/serverless-api/examples/deploy.js
+++ b/packages/serverless-api/examples/deploy.js
@@ -10,7 +10,7 @@ async function run() {
   const result = await client.deployProject({
     ...config,
     overrideExistingService: true,
-    runtime: 'node16',
+    runtime: 'node18',
     env: {
       HELLO: 'ahoy',
       WORLD: 'welt',

--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -44,7 +44,7 @@ type DeployProjectConfigBase = {
    */
   overrideExistingService?: boolean;
   /**
-   * Version of Node.js to deploy with in Twilio Runtime. Can be "node16"
+   * Version of Node.js to deploy with in Twilio Runtime. Can be "node18"
    */
   runtime?: string;
 };

--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -36,7 +36,7 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// \\"production\\": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,
 	// \\"properties\\": null 	/* Specify the output properties you want to see. Works best on single types */,
 	// \\"region\\": null 	/* Twilio API Region */,
-	\\"runtime\\": \\"node16\\" 	/* The version of Node.js to deploy the build to. (node16) */,
+	\\"runtime\\": \\"node18\\" 	/* The version of Node.js to deploy the build to. (node18) */,
 	// \\"serviceName\\": null 	/* Overrides the name of the Serverless project. Default: the name field in your package.json */,
 	// \\"serviceSid\\": null 	/* SID of the Twilio Serverless Service to deploy to */,
 	// \\"sourceEnvironment\\": null 	/* SID or suffix of an existing environment you want to deploy from. */,

--- a/packages/twilio-run/src/checks/nodejs-version.ts
+++ b/packages/twilio-run/src/checks/nodejs-version.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 import { logger } from '../utils/logger';
 
-const SERVERLESS_NODE_JS_VERSION = ['14.', '16.'];
+const SERVERLESS_NODE_JS_VERSION = ['16.', '18.'];
 
 export function printVersionWarning(
   nodeVersion: string,

--- a/packages/twilio-run/src/flags.ts
+++ b/packages/twilio-run/src/flags.ts
@@ -228,7 +228,7 @@ export const ALL_FLAGS = {
   } as Options,
   runtime: {
     type: 'string',
-    describe: 'The version of Node.js to deploy the build to. (node16)',
+    describe: 'The version of Node.js to deploy the build to. (node18)',
   } as Options,
   key: {
     type: 'string',

--- a/packages/twilio-run/src/templating/defaultConfig.ts
+++ b/packages/twilio-run/src/templating/defaultConfig.ts
@@ -9,7 +9,7 @@ import { getDebugFunction } from '../utils/logger';
 
 const debug = getDebugFunction('twilio-run:templating:defaultConfig');
 
-const DEFAULT_RUNTIME = 'node16';
+const DEFAULT_RUNTIME = 'node18';
 
 function renderDefault(config: Options): string {
   if (config.type === 'boolean') {


### PR DESCRIPTION
Upgrading support in serverless to node18 and making it default

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
