### PR TITLE
FRIDGE-1084 Change default concurrency limit

### DIFF
--- a/.changeset/sour-goats-help.md
+++ b/.changeset/sour-goats-help.md
@@ -1,0 +1,6 @@
+---
+'@twilio-labs/plugin-serverless': patch
+'@twilio-labs/serverless-api': patch
+---
+
+Change default concurrency limit from 50 to 10

--- a/packages/plugin-serverless/README.md
+++ b/packages/plugin-serverless/README.md
@@ -43,8 +43,8 @@ USAGE
 ### Concurrency
 
 When deploying lots of Functions and Assets it is possible to run up against the enforced concurrency limits of the Twilio API. You can limit the concurrency and set how many times the library retries API requests using environment variables.
-
-The default concurrency is 50 and the default number of retries is 10. You can change this by setting environment variables. The following would set concurrency to 1, only 1 live request at a time, and retries to 0, so if it fails it won't retry.
+It is advisable to keep the concurrency low (around 10-15) to avoid hitting the rate limits of the Twilio API.
+The default concurrency is 10 and the default number of retries is 10. You can change this by setting environment variables. The following would set concurrency to 1, only 1 live request at a time, and retries to 0, so if it fails it won't retry.
 
 ```sh-session
 export TWILIO_SERVERLESS_API_CONCURRENCY=1

--- a/packages/serverless-api/src/api/utils/http_config.ts
+++ b/packages/serverless-api/src/api/utils/http_config.ts
@@ -5,7 +5,7 @@ if (typeof retryLimit === 'undefined') {
 
 let concurrency = process.env.TWILIO_SERVERLESS_API_CONCURRENCY;
 if (typeof concurrency === 'undefined') {
-  concurrency = '50';
+  concurrency = '10';
 }
 
 export const RETRY_LIMIT = parseInt(retryLimit, 10);


### PR DESCRIPTION
When multiple files are present in a project, you will get 429 as the toolkit spams API with requests and does not seem to do any sort of retries or uploading respecting endpoint rate limits. This is caused by the requests breaking the rate limits of some Twilio apis. 

With this change the default concurrency limit is reduced, so avoid hitting rate limits.



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
