### PR TITLE
fix(twilio-run): handle adding object as header correctly as an error

### DIFF
--- a/.changeset/three-gifts-smash.md
+++ b/.changeset/three-gifts-smash.md
@@ -1,0 +1,6 @@
+---
+'@twilio/runtime-handler': minor
+'twilio-run': minor
+---
+
+handle adding object as header correctly as an error

--- a/packages/runtime-handler/__tests__/dev-runtime/internal/response.test.ts
+++ b/packages/runtime-handler/__tests__/dev-runtime/internal/response.test.ts
@@ -84,6 +84,17 @@ test('sets headers with string cookies', () => {
   expect(response['headers']).toEqual(expected);
 });
 
+test('object cant be a header', () => {
+  const response = new Response();
+  expect(response['headers']).toEqual({
+    'Set-Cookie': [],
+  });
+
+  expect(() => {
+    response.appendHeader('Access-Control-Allow-Origin', {} as any);
+  }).toThrow('Header value cannot be an object');
+});
+
 test('sets headers with an array of cookies', () => {
   const response = new Response();
   expect(response['headers']).toEqual({

--- a/packages/runtime-handler/src/dev-runtime/internal/response.ts
+++ b/packages/runtime-handler/src/dev-runtime/internal/response.ts
@@ -70,6 +70,11 @@ export class Response implements TwilioResponse {
   appendHeader(key: string, value: HeaderValue): Response {
     log('Appending header for %s', key, value);
     this.headers = this.headers || {};
+
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      throw new Error('Header value cannot be an object');
+    }
+
     let newHeaderValue: HeaderValue = [];
     if (key.toLowerCase() === COOKIE_HEADER.toLowerCase()) {
       const existingValue = this.headers[COOKIE_HEADER];

--- a/packages/twilio-run/__tests__/runtime/internal/response.test.ts
+++ b/packages/twilio-run/__tests__/runtime/internal/response.test.ts
@@ -85,6 +85,17 @@ test('appends a new header correctly', () => {
   });
 });
 
+test('object cant be a header', () => {
+  const response = new Response();
+  expect(response['headers']).toEqual({
+    'Set-Cookie': [],
+  });
+
+  expect(() => {
+    response.appendHeader('Access-Control-Allow-Origin', {} as any);
+  }).toThrow('Header value cannot be an object');
+});
+
 test('appends a header correctly with no existing one', () => {
   const response = new Response();
   expect(response['headers']).toEqual({

--- a/packages/twilio-run/src/runtime/internal/response.ts
+++ b/packages/twilio-run/src/runtime/internal/response.ts
@@ -67,6 +67,9 @@ export class Response implements TwilioResponse {
 
   appendHeader(key: string, value: HeaderValue): Response {
     debug('Appending header for %s', key, value);
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      throw new Error('Header value cannot be an object');
+    }
     this.headers = this.headers || {};
     let newHeaderValue: HeaderValue = [];
     if (key.toLowerCase() === COOKIE_HEADER.toLowerCase()) {


### PR DESCRIPTION
handle adding object as header correctly as an error

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
