### PR TITLE
fix(twilio-run): handle adding object as header correctly as an error

### DIFF
--- a/.changeset/cyan-carrots-compete.md
+++ b/.changeset/cyan-carrots-compete.md
@@ -1,0 +1,6 @@
+---
+"@twilio-labs/plugin-assets": patch
+"@twilio-labs/serverless-twilio-runtime": patch
+---
+
+fix(twilio-run): handle adding object as header correctly as an error

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.1.2",
-    "typedoc": "^0.26.5",
+    "typedoc": "^0.27.4",
     "typescript": "^5.3.3"
   },
   "lint-staged": {

--- a/packages/plugin-assets/package.json
+++ b/packages/plugin-assets/package.json
@@ -9,7 +9,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@oclif/core": "^1.14.2",
-    "@twilio-labs/serverless-api": "^5.5.0",
+    "@twilio-labs/serverless-api": "^5.5.2",
     "@twilio/cli-core": "^7.0.0",
     "inquirer": "^8.0.0",
     "ora": "^5.4.0",

--- a/packages/serverless-twilio-runtime/package.json
+++ b/packages/serverless-twilio-runtime/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/twilio-labs/serverless-toolkit/issues"
   },
   "dependencies": {
-    "@twilio-labs/serverless-api": "^1.0.1"
+    "@twilio-labs/serverless-api": "^5.5.2"
   },
   "gitHead": "9382ba7f1c23cdf18ac8bb6cada92340d63491dd"
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
