### PR TITLE
Adding UiEditable param to createService

### DIFF
--- a/.changeset/spicy-buckets-count.md
+++ b/.changeset/spicy-buckets-count.md
@@ -1,6 +1,6 @@
 ---
-"@twilio-labs/serverless-api": patch
-"@twilio-labs/plugin-serverless": patch
+"@twilio-labs/serverless-api": minor
+"@twilio-labs/plugin-serverless": minor
 ---
 
 Adding UiEditable param to createService

--- a/.changeset/spicy-buckets-count.md
+++ b/.changeset/spicy-buckets-count.md
@@ -1,0 +1,6 @@
+---
+"@twilio-labs/serverless-api": patch
+"@twilio-labs/plugin-serverless": patch
+---
+
+Adding UiEditable param to createService

--- a/packages/plugin-serverless/src/utils.js
+++ b/packages/plugin-serverless/src/utils.js
@@ -80,6 +80,7 @@ function createExternalCliOptions(flags, twilioClient) {
   const pluginInfo = {
     version: pkgJson.version,
     name: pkgJson.name,
+    uiEditable: pkgJson.uiEditable,
   };
 
   if (

--- a/packages/serverless-api/src/api/services.ts
+++ b/packages/serverless-api/src/api/services.ts
@@ -14,11 +14,13 @@ const log = debug('twilio-serverless-api:services');
  * @export
  * @param {string} serviceName the unique name for the service
  * @param {TwilioServerlessApiClient} client API client
+ * @param {boolean} uiEditable Whether the Service's properties and subresources can be edited via the UI. The default value is false.
  * @returns {Promise<string>}
  */
 export async function createService(
   serviceName: string,
-  client: TwilioServerlessApiClient
+  client: TwilioServerlessApiClient,
+  uiEditable: boolean = false
 ): Promise<string> {
   try {
     const resp = await client.request('post', 'Services', {
@@ -26,9 +28,10 @@ export async function createService(
         UniqueName: serviceName,
         FriendlyName: serviceName,
         IncludeCredentials: true,
+        UiEditable: uiEditable,
       },
     });
-    const service = (resp.body as unknown) as ServiceResource;
+    const service = resp.body as unknown as ServiceResource;
 
     return service.sid;
   } catch (err) {
@@ -82,7 +85,7 @@ export async function getService(
 ): Promise<ServiceResource> {
   try {
     const resp = await client.request('get', `Services/${sid}`);
-    return (resp.body as unknown) as ServiceResource;
+    return resp.body as unknown as ServiceResource;
   } catch (err) {
     log('%O', new ClientApiError(err));
     throw err;

--- a/packages/serverless-api/src/client.ts
+++ b/packages/serverless-api/src/client.ts
@@ -507,13 +507,8 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
    */
   async activateBuild(activateConfig: ActivateConfig): Promise<ActivateResult> {
     try {
-      let {
-        buildSid,
-        targetEnvironment,
-        serviceSid,
-        sourceEnvironment,
-        env,
-      } = activateConfig;
+      let { buildSid, targetEnvironment, serviceSid, sourceEnvironment, env } =
+        activateConfig;
 
       if (!buildSid && !sourceEnvironment) {
         const error = new Error(
@@ -630,7 +625,11 @@ export class TwilioServerlessApiClient extends events.EventEmitter {
           message: 'Creating Service',
         });
         try {
-          serviceSid = await createService(config.serviceName, this);
+          serviceSid = await createService(
+            config.serviceName,
+            this,
+            config.uiEditable
+          );
         } catch (err) {
           const alternativeServiceSid = await findServiceSid(
             config.serviceName,

--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -47,6 +47,10 @@ type DeployProjectConfigBase = {
    * Version of Node.js to deploy with in Twilio Runtime. Can be "node18"
    */
   runtime?: string;
+  /**
+   * Whether the Service's properties and subresources can be edited via the UI. The default value is false.
+   */
+  uiEditable?: boolean;
 };
 
 /**

--- a/packages/serverless-api/src/types/serverless-api.ts
+++ b/packages/serverless-api/src/types/serverless-api.ts
@@ -48,6 +48,7 @@ export interface ServiceResource extends UpdateableResourceBase {
   unique_name: string;
   include_credentials: boolean;
   friendly_name: string;
+  ui_editable?: boolean;
 }
 
 export interface ServiceList extends BaseList<'services'> {


### PR DESCRIPTION
Adding UiEditable param to createService

Resolves https://github.com/twilio-labs/serverless-toolkit/issues/134. 

The [Create a Service resource](https://www.twilio.com/docs/serverless/api/resource/service#create-a-service-resource) allows a developer to set a `UiEditable` boolean flag (defaults to `false`).

This PR allows a developer to configure a `uiEditable` JSON key in the `package.json` file. If it is not set, it defaults to `false`. 

Note: The serverless toolkit's serverless-api services API does not support updating services. So this will only work when calling `createService`. This could be updated in the future. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
