### PR TITLE
Display access visibility for public assets and functions on deploy.

### DIFF
--- a/packages/twilio-run/src/printers/deploy.ts
+++ b/packages/twilio-run/src/printers/deploy.ts
@@ -160,7 +160,7 @@ function prettyPrintDeployedResources(
       .sort(sortByAccess)
       .map((fn) => {
         const accessPrefix =
-          fn.access !== 'public' ? chalk`{bold [${fn.access}]} ` : '';
+          chalk`{bold [${fn.access}]} `;
         return chalk`   ${accessPrefix}{dim https://${result.domain}}${fn.path}`;
       })
       .join('\n');
@@ -173,7 +173,7 @@ function prettyPrintDeployedResources(
       .sort(sortByAccess)
       .map((asset) => {
         const accessPrefix =
-          asset.access !== 'public' ? chalk`{bold [${asset.access}]} ` : '';
+          chalk`{bold [${asset.access}]} `;
         const accessUrl =
           asset.access === 'private'
             ? chalk`{dim Runtime.getAssets()['}${asset.path}{dim ']}`


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Display visibility for `public` assets and functions on deploy. Clarifies when an asset or function has been deployed publicly, helping users quickly identify and address potential security concerns

![Screenshot 2025-01-21 at 13 24 22](https://github.com/user-attachments/assets/c7cc06bd-df82-43fe-a478-40fa4ac1f3bd)


> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
