### PR TITLE
Add scoped environment files to .gitignore

### DIFF
--- a/packages/create-twilio-function/src/create-twilio-function/create-gitignore.js
+++ b/packages/create-twilio-function/src/create-twilio-function/create-gitignore.js
@@ -2,7 +2,7 @@ const { createWriteStream } = require('fs');
 const { join } = require('path');
 const gitignore = require('gitignore');
 
-const ADDITIONAL_CONTENT = '# Twilio Serverless\n.twiliodeployinfo\n\n';
+const ADDITIONAL_CONTENT = '# Twilio Serverless\n.twiliodeployinfo\n.env.prod\n.env.dev\n.env.stage\n\n';
 
 function createGitignore(dirPath) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
chore: add environment files to .gitignore

Added .env.prod, .env.dev, and .env.stage to .gitignore to prevent sensitive environment configurations from being tracked in version control.

While .env entries already exist in .gitignore, they do not follow the example naming convention outlined in the Twilio documentation:
[Twilio Scoped Configurations](https://www.twilio.com/docs/labs/serverless-toolkit/configuration#scoped-configurations).

This update aligns with best practices and ensures consistency with documented naming conventions.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
