### PR TITLE
 TECHEMPROD-1428 - Fix broken reference to TwilioClientOptions

### DIFF
--- a/packages/serverless-runtime-types/types.d.ts
+++ b/packages/serverless-runtime-types/types.d.ts
@@ -2,7 +2,7 @@ import * as twilio from 'twilio';
 import { ServiceContext } from 'twilio/lib/rest/sync/v1/service';
 import { SyncListListInstance } from 'twilio/lib/rest/sync/v1/service/syncList';
 import { SyncMapListInstance } from 'twilio/lib/rest/sync/v1/service/syncMap';
-import { TwilioClientOptions } from 'twilio/lib/rest/Twilio';
+export {  RequestClientOptions as TwilioClientOptions  } from 'twilio/lib/rest/Twilio';
 
 export type EnvironmentVariables = {
   [key: string]: string | undefined;
@@ -412,6 +412,6 @@ export type GlobalTwilio = Omit<typeof twilio, 'default'> & {
 export { ServiceContext } from 'twilio/lib/rest/sync/v1/service';
 export { SyncListListInstance } from 'twilio/lib/rest/sync/v1/service/syncList';
 export { SyncMapListInstance } from 'twilio/lib/rest/sync/v1/service/syncMap';
-export { TwilioClientOptions } from 'twilio/lib/rest/Twilio';
+export {  RequestClientOptions as TwilioClientOptions  } from 'twilio/lib/rest/Twilio';
 export type TwilioClient = twilio.Twilio;
 export type TwilioPackage = typeof twilio;


### PR DESCRIPTION
Starting Twilio NodeJS SDK version 4.0.0, the reference  for TwilioClientOptions was removed. I included the right option: RequestClientOptions to fix the TS compiling process.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
