### PR TITLE
feat(runtime-handler): export Response class for testing

### DIFF
--- a/.changeset/export-response-class.md
+++ b/.changeset/export-response-class.md
@@ -1,0 +1,5 @@
+---
+"@twilio/runtime-handler": minor
+---
+
+Export Response class from the package root for use in testing. Previously, the package's main entry was a placeholder that threw on import. Now `const { Response } = require('@twilio/runtime-handler')` provides the same Response class used by the local dev runtime, enabling proper unit testing of Twilio Functions without custom mocks.

--- a/packages/runtime-handler/__tests__/runtime-handler.test.ts
+++ b/packages/runtime-handler/__tests__/runtime-handler.test.ts
@@ -1,5 +1,11 @@
-test('base should not be importable', () => {
-  expect(() => {
-    require('..');
-  }).toThrow();
+test('base export includes Response class', () => {
+  const { Response } = require('..');
+  expect(Response).toBeDefined();
+  expect(typeof Response).toBe('function');
+
+  const res = new Response();
+  expect(res.setStatusCode).toBeDefined();
+  expect(res.setBody).toBeDefined();
+  expect(res.appendHeader).toBeDefined();
+  expect(res.setCookie).toBeDefined();
 });

--- a/packages/runtime-handler/package.json
+++ b/packages/runtime-handler/package.json
@@ -9,11 +9,12 @@
   "author": "Twilio Inc. <open-source@twilio.com> (https://www.twilio.com/labs)",
   "homepage": "https://github.com/twilio-labs/serverless-toolkit/tree/main/packages/runtime-handler#readme",
   "license": "MIT",
-  "main": "dist/invalid.js",
-  "types": "dist/invalid.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/invalid.js",
-    "./dev": "./dist/dev-runtime/dev-runtime.js"
+    ".": "./dist/index.js",
+    "./dev": "./dist/dev-runtime/dev-runtime.js",
+    "./testing": "./dist/index.js"
   },
   "directories": {
     "src": "src",

--- a/packages/runtime-handler/src/index.ts
+++ b/packages/runtime-handler/src/index.ts
@@ -1,1 +1,1 @@
-// placeholder
+export { Response } from './dev-runtime/internal/response';


### PR DESCRIPTION
## Summary

Export the `Response` class from `@twilio/runtime-handler` so it can be used in unit tests without custom mocks.

Closes #384

## Problem

Every developer testing Twilio Functions must create their own mock `Response` class because the real implementation is internal to the runtime-handler package. The package's `index.ts` was literally `// placeholder` and the main entry threw on import.

## Solution

- Export `Response` from `src/index.ts`
- Update `package.json` main/types to point to the real index
- Add `./testing` subpath export for explicit test usage
- Update test to verify the export works

## Usage

```js
const { Response } = require('@twilio/runtime-handler');
// or
const { Response } = require('@twilio/runtime-handler/testing');
```

## Testing

All 52 test suites pass (410 tests). The `runtime-handler.test.ts` now verifies the export works with method presence checks.