### PR TITLE
feat: add node24 CLI runtime support

### DIFF
--- a/.changeset/add-node24-runtime.md
+++ b/.changeset/add-node24-runtime.md
@@ -5,4 +5,4 @@
 "@twilio-labs/plugin-serverless": minor
 ---
 
-chore: update toolkit to default to node24
+feat: add node24 as supported runtime and update default from node22 to node24

--- a/.changeset/add-node24-runtime.md
+++ b/.changeset/add-node24-runtime.md
@@ -1,0 +1,8 @@
+---
+"@twilio-labs/serverless-api": minor
+"twilio-run": minor
+"create-twilio-function": minor
+"@twilio-labs/plugin-serverless": minor
+---
+
+chore: update toolkit to default to node24

--- a/packages/create-twilio-function/src/create-twilio-function/versions.js
+++ b/packages/create-twilio-function/src/create-twilio-function/versions.js
@@ -6,7 +6,7 @@ module.exports = {
     '@twilio/runtime-handler'
   ].replace(/[\^~]/, ''),
   twilioRun: pkgJson.dependencies['twilio-run'],
-  node: '^20.x || ^22.x',
+  node: '^20.x || ^22.x || ^24.x',
   typescript: '^5.3.3',
   serverlessRuntimeTypes: '^4.0.0',
   copyfiles: '^2.4.1',

--- a/packages/plugin-serverless/README.md
+++ b/packages/plugin-serverless/README.md
@@ -158,7 +158,7 @@ FLAGS
       --password=<value>           A specific API secret or auth token for deployment. Uses fields from .env otherwise
       --production                 Please prefer the "activate" command! Deploys to the production environment (no
                                    domain suffix). Overrides the value passed via the environment flag.
-      --runtime=<value>            The version of Node.js to deploy the build to. (node22)
+      --runtime=<value>            The version of Node.js to deploy the build to. (node24)
       --service-sid=<value>        SID of the Twilio Serverless Service to deploy to
       --silent                     Suppress  output and logs. This is a shorthand for "-l none -o none".
       --to=<value>                 [Alias for "environment"]

--- a/packages/plugin-serverless/README.md
+++ b/packages/plugin-serverless/README.md
@@ -158,7 +158,7 @@ FLAGS
       --password=<value>           A specific API secret or auth token for deployment. Uses fields from .env otherwise
       --production                 Please prefer the "activate" command! Deploys to the production environment (no
                                    domain suffix). Overrides the value passed via the environment flag.
-      --runtime=<value>            The version of Node.js to deploy the build to. (node24)
+      --runtime=<value>            The version of Node.js to deploy the build to. (node22)
       --service-sid=<value>        SID of the Twilio Serverless Service to deploy to
       --silent                     Suppress  output and logs. This is a shorthand for "-l none -o none".
       --to=<value>                 [Alias for "environment"]

--- a/packages/serverless-api/examples/deploy.js
+++ b/packages/serverless-api/examples/deploy.js
@@ -10,7 +10,7 @@ async function run() {
   const result = await client.deployProject({
     ...config,
     overrideExistingService: true,
-    runtime: 'node24',
+    runtime: 'node22',
     env: {
       HELLO: 'ahoy',
       WORLD: 'welt',

--- a/packages/serverless-api/examples/deploy.js
+++ b/packages/serverless-api/examples/deploy.js
@@ -10,7 +10,7 @@ async function run() {
   const result = await client.deployProject({
     ...config,
     overrideExistingService: true,
-    runtime: 'node22',
+    runtime: 'node24',
     env: {
       HELLO: 'ahoy',
       WORLD: 'welt',

--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -44,7 +44,7 @@ type DeployProjectConfigBase = {
    */
   overrideExistingService?: boolean;
   /**
-   * Version of Node.js to deploy with in Twilio Runtime. Can be "node22"
+   * Version of Node.js to deploy with in Twilio Runtime. Can be "node24"
    */
   runtime?: string;
   /**

--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -44,7 +44,7 @@ type DeployProjectConfigBase = {
    */
   overrideExistingService?: boolean;
   /**
-   * Version of Node.js to deploy with in Twilio Runtime. Can be "node24"
+   * Version of Node.js to deploy with in Twilio Runtime. Can be "node22"
    */
   runtime?: string;
   /**

--- a/packages/serverless-api/src/types/deploy.ts
+++ b/packages/serverless-api/src/types/deploy.ts
@@ -44,7 +44,7 @@ type DeployProjectConfigBase = {
    */
   overrideExistingService?: boolean;
   /**
-   * Version of Node.js to deploy with in Twilio Runtime. Can be "node24"
+   * Version of Node.js to deploy with in Twilio Runtime. Can be "node22" or "node24"
    */
   runtime?: string;
   /**

--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -36,7 +36,7 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// "production": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,
 	// "properties": null 	/* Specify the output properties you want to see. Works best on single types */,
 	// "region": null 	/* Twilio API Region */,
-	"runtime": "node22" 	/* The version of Node.js to deploy the build to. (node22) */,
+	"runtime": "node24" 	/* The version of Node.js to deploy the build to. (node24) */,
 	// "serviceName": null 	/* Overrides the name of the Serverless project. Default: the name field in your package.json */,
 	// "serviceSid": null 	/* SID of the Twilio Serverless Service to deploy to */,
 	// "sourceEnvironment": null 	/* SID or suffix of an existing environment you want to deploy from. */,

--- a/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
+++ b/packages/twilio-run/__tests__/templating/__snapshots__/defaultConfig.test.ts.snap
@@ -36,7 +36,7 @@ exports[`writeDefaultConfigFile default file should match snapshot 1`] = `
 	// "production": false 	/* Promote build to the production environment (no domain suffix). Overrides environment flag */,
 	// "properties": null 	/* Specify the output properties you want to see. Works best on single types */,
 	// "region": null 	/* Twilio API Region */,
-	"runtime": "node24" 	/* The version of Node.js to deploy the build to. (node24) */,
+	"runtime": "node22" 	/* The version of Node.js to deploy the build to. (node22) */,
 	// "serviceName": null 	/* Overrides the name of the Serverless project. Default: the name field in your package.json */,
 	// "serviceSid": null 	/* SID of the Twilio Serverless Service to deploy to */,
 	// "sourceEnvironment": null 	/* SID or suffix of an existing environment you want to deploy from. */,

--- a/packages/twilio-run/src/checks/nodejs-version.ts
+++ b/packages/twilio-run/src/checks/nodejs-version.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 import { logger } from '../utils/logger';
 
-const SERVERLESS_NODE_JS_VERSION = ['20.', '22.'];
+const SERVERLESS_NODE_JS_VERSION = ['20.', '22.', '24.'];
 
 export function printVersionWarning(
   nodeVersion: string,

--- a/packages/twilio-run/src/flags.ts
+++ b/packages/twilio-run/src/flags.ts
@@ -228,7 +228,7 @@ export const ALL_FLAGS = {
   } as Options,
   runtime: {
     type: 'string',
-    describe: 'The version of Node.js to deploy the build to. (node24)',
+    describe: 'The version of Node.js to deploy the build to. (node22)',
   } as Options,
   key: {
     type: 'string',

--- a/packages/twilio-run/src/flags.ts
+++ b/packages/twilio-run/src/flags.ts
@@ -228,7 +228,7 @@ export const ALL_FLAGS = {
   } as Options,
   runtime: {
     type: 'string',
-    describe: 'The version of Node.js to deploy the build to. (node22)',
+    describe: 'The version of Node.js to deploy the build to. (node24)',
   } as Options,
   key: {
     type: 'string',

--- a/packages/twilio-run/src/templating/defaultConfig.ts
+++ b/packages/twilio-run/src/templating/defaultConfig.ts
@@ -9,7 +9,7 @@ import { getDebugFunction } from '../utils/logger';
 
 const debug = getDebugFunction('twilio-run:templating:defaultConfig');
 
-const DEFAULT_RUNTIME = 'node24';
+const DEFAULT_RUNTIME = 'node22';
 
 function renderDefault(config: Options): string {
   if (config.type === 'boolean') {

--- a/packages/twilio-run/src/templating/defaultConfig.ts
+++ b/packages/twilio-run/src/templating/defaultConfig.ts
@@ -9,7 +9,7 @@ import { getDebugFunction } from '../utils/logger';
 
 const debug = getDebugFunction('twilio-run:templating:defaultConfig');
 
-const DEFAULT_RUNTIME = 'node22';
+const DEFAULT_RUNTIME = 'node24';
 
 function renderDefault(config: Options): string {
   if (config.type === 'boolean') {


### PR DESCRIPTION
## Summary

- Adds `node24` as a valid runtime option in the CLI
- Updates default runtime from `node22` to `node24`
- Updates Node.js version check allowlist to include `24.x`
- Updates `create-twilio-function` engine range to include `^24.x`

## Changes

- `packages/twilio-run/src/templating/defaultConfig.ts` — default runtime → `node24`
- `packages/twilio-run/src/flags.ts` — `--help` output updated to reference `node24`
- `packages/twilio-run/src/checks/nodejs-version.ts` — `24.` added to accepted versions
- `packages/create-twilio-function/src/create-twilio-function/versions.js` — node engine range extended to `^24.x`
- `packages/serverless-api/src/types/deploy.ts` — doc comment updated
- `packages/serverless-api/examples/deploy.js` — example updated to `node24`
- `packages/plugin-serverless/README.md` — `--runtime` help text updated
- `.changeset/add-node24-runtime.md` — changeset added

## Reference

- Jira: FNA-1108
- Reference PR (node22): https://github.com/twilio-labs/serverless-toolkit/pull/540

## Test plan

- [ ] All existing toolkit tests pass
- [ ] `twilio serverless:deploy --runtime node24` deploys successfully
- [ ] `--help` output shows `(node24)` for `--runtime` flag