### PR TITLE
fix: correct supported Node.js version messaging

### DIFF
--- a/.changeset/node-version-warning-cleanup.md
+++ b/.changeset/node-version-warning-cleanup.md
@@ -1,0 +1,11 @@
+---
+'twilio-run': patch
+'@twilio-labs/serverless-twilio-runtime': patch
+---
+
+fix: correct supported Node.js version messaging
+
+The local Node.js version warning rendered the supported versions as
+`20.,22.x` because the version array was interpolated directly; it now
+reads `20.x, 22.x`. Also updated the serverless-twilio-runtime README to
+list both supported runtimes (v20.x and v22.x) instead of only v20.x.

--- a/packages/serverless-twilio-runtime/Readme.md
+++ b/packages/serverless-twilio-runtime/Readme.md
@@ -8,7 +8,7 @@ Serverless Framework plugin to deploy to the Twilio Runtime.
 
 ### Pre-requisites
 
-- Node.js v20.x (this is the runtime version supported by Twilio Functions)
+- Node.js v20.x or v22.x (these are the runtime versions supported by Twilio Functions)
 - Serverless CLI v1.50.0+. You can run npm i -g serverless if you don't already have it.
 - A Twilio account. If you don't have one you can [sign up quickly](https://www.twilio.com/try-twilio).
 

--- a/packages/twilio-run/src/checks/nodejs-version.ts
+++ b/packages/twilio-run/src/checks/nodejs-version.ts
@@ -8,8 +8,11 @@ export function printVersionWarning(
   expectedVersion: string[]
 ): void {
   const title = 'Different Node.js Version Found';
+  const supportedVersions = expectedVersion
+    .map((version) => `${version}x`)
+    .join(', ');
   const msg = stripIndent`
-      You are currently running Node.js ${nodeVersion} on this local machine. The production environment for Twilio Serverless currently supports versions ${expectedVersion}x.
+      You are currently running Node.js ${nodeVersion} on this local machine. The production environment for Twilio Serverless currently supports versions ${supportedVersions}.
 
       When you deploy to Twilio Serverless, you may encounter differences between local development and production.
 


### PR DESCRIPTION
The local Node.js version warning interpolated the version array directly, printing "20.,22.x"; it now renders "20.x, 22.x". Also update the serverless-twilio-runtime README to list both supported runtimes (v20.x and v22.x) instead of only v20.x.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
