### PR TITLE
fix(twilio-run): align @twilio/runtime-handler dep with create-twilio-function

### DIFF
--- a/.changeset/runtime-handler-version-alignment.md
+++ b/.changeset/runtime-handler-version-alignment.md
@@ -1,0 +1,7 @@
+---
+'twilio-run': patch
+---
+
+fix: align `@twilio/runtime-handler` dev dependency with the version scaffolded by `create-twilio-function`
+
+`twilio-run` depended on `@twilio/runtime-handler@^2.1.0` while `create-twilio-function` pins `^2.0.3`. The two were inconsistent, and `2.1.0` — although published to npm as `latest` — is currently rejected by the Twilio Serverless platform at deploy time (`Error 20001: No matching version found for @twilio/runtime-handler@2.1.0`). Pinning `twilio-run` to `^2.0.3` keeps the monorepo internally consistent and avoids signalling a version that cannot be deployed. See #557.

--- a/packages/twilio-run/package.json
+++ b/packages/twilio-run/package.json
@@ -86,7 +86,7 @@
     "@ngrok/ngrok": "^1.7.0"
   },
   "devDependencies": {
-    "@twilio/runtime-handler": "^2.1.0",
+    "@twilio/runtime-handler": "^2.0.3",
     "@types/cheerio": "^0.22.12",
     "@types/common-tags": "^1.8.0",
     "@types/debug": "^4.1.4",


### PR DESCRIPTION
twilio-run declared @twilio/runtime-handler@^2.1.0 while create-twilio-function pins ^2.0.3. The two were inconsistent, and 2.1.0 — though published to npm as 'latest' — is currently rejected by the Twilio Serverless platform at deploy time (Error 20001). Pin twilio-run to ^2.0.3 to keep the monorepo internally consistent and avoid signalling a non-deployable version.

Refs #557

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
