### PR TITLE
FNA-1286: fix release workflow blocked by enterprise Actions policy

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [ lts/-1, lts/*]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Update npm to 8.x

--- a/.github/workflows/noresponse.yml
+++ b/.github/workflows/noresponse.yml
@@ -4,11 +4,7 @@ name: No Response
 # to work properly.
 # Details here: https://github.com/lee-dohm/no-response/blob/main/action.yml
 on:
-  issue_comment:
-    types: [created]
-  schedule:
-    # Schedule for 00:00 UTC every day
-    - cron: '0 0 * * *'
+  workflow_dispatch: # disabled: lee-dohm/no-response is blocked by enterprise policy
 
 jobs:
   noResponse:

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -17,9 +17,12 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js 20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 20
       - name: Update npm to 10.x
@@ -35,12 +38,40 @@ jobs:
         run: |
           npm run clean
           npm run build
-      - name: "Create Pull Request or Publish to npm"
-        uses: changesets/action@v1
-        with:
-          version: npm run version-packages
-          publish: npm run npm:publish
-          commit: "chore: version packages"
+      - name: Check for changesets
+        id: changesets
+        run: |
+          if [ -n "$(find .changeset -name '*.md' -not -name 'README.md')" ]; then
+            echo "has_changesets=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changesets=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Create Pull Request or Publish to npm
+        run: |
+          if [ "${{ steps.changesets.outputs.has_changesets }}" = "true" ]; then
+            # Changesets exist — open/update a version PR
+            npm run version-packages
+            git add -A
+            git status
+            if git diff --cached --quiet; then
+              echo "No version changes to commit"
+            else
+              git commit -m "chore: version packages"
+              BRANCH="changeset-release/main"
+              git checkout -b "$BRANCH" 2>/dev/null || git checkout "$BRANCH"
+              git push origin "$BRANCH" --force
+              gh pr create \
+                --title "chore: version packages" \
+                --body "This PR was opened by the release workflow. Merge to publish to npm." \
+                --base main \
+                --head "$BRANCH" \
+              || gh pr edit "$BRANCH" --title "chore: version packages"
+            fi
+          else
+            # No changesets — publish any packages whose version exceeds what is on npm
+            npm run npm:publish
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Jira: https://twilio-engineering.atlassian.net/browse/FNA-1286

## Background

This repo uses [Changesets](https://github.com/changesets/changesets) to manage versioning and npm publishing. The flow is:

1. A developer merges a PR that includes a \`.changeset/*.md\` file describing what changed and which packages bump (patch/minor/major).
2. When that lands on \`main\`, the \`on-merge-main.yml\` workflow runs and uses the \`changesets/action\` to either:
   - **Open a "Version Packages" PR** — bumps \`package.json\` versions and updates changelogs based on pending changesets, or
   - **Publish to npm** — if a Version Packages PR was already merged (changesets consumed), publishes the new versions.

## What broke

After PR #555 was merged, the \`Merge to main\` workflow failed immediately with \`startup_failure\` — GitHub could not even start the workflow, zero jobs ran.

The error was:

> The actions \`changesets/action@v1\`, \`actions/checkout@v3\`, \`actions/setup-node@v3\`, and \`actions/checkout@v4\` are not allowed in twilio-labs/serverless-toolkit because all actions must be from a repository owned by your enterprise or created by GitHub. All actions must also be pinned to a full-length commit SHA.

This is Twilio's enterprise GitHub Actions security policy, which requires:
1. Actions must be either owned by GitHub (\`actions/*\`) or the enterprise — no arbitrary third-party actions.
2. Even allowed actions must reference an exact commit SHA (e.g. \`actions/checkout@abc123...\`), not a floating tag like \`@v3\`, to prevent supply-chain attacks where a tag is silently moved to malicious code.

\`startup_failure\` runs cannot be re-run, and the workflow only triggers on push to \`main\`, so the release was completely stuck.

## What each blocked action was doing

### \`changesets/action@v1\` (third-party — fully blocked)

This is the main [Changesets](https://github.com/changesets/changesets) GitHub Action maintained by the Changesets project, not GitHub. It automated the entire release cycle:

- Detected whether any \`.changeset/*.md\` files exist on \`main\`.
- If yes: ran \`changeset version\` (bumps \`package.json\` files, writes changelogs, deletes consumed changeset files) and opened/updated a PR titled "Version Packages".
- If no pending changesets (i.e. the Version Packages PR was just merged): ran \`changeset publish\` to push all packages whose local version exceeds what's on npm.

**Replacement:** Rewrote this as a shell script in the workflow that does the same two-branch logic using the \`npm run version-packages\` and \`npm run npm:publish\` scripts that already exist in \`package.json\`, plus \`gh pr create\` to open the version PR.

### \`actions/checkout@v3\` / \`actions/checkout@v4\` (GitHub-owned — allowed but not pinned)

These are GitHub's official action for checking out the repository code onto the runner. They are allowed by policy (GitHub-owned), but were referenced by floating tag (\`@v3\`, \`@v4\`) rather than a full commit SHA.

**Fix:** Pinned both to their exact commit SHAs:
- \`actions/checkout@v3\` → \`actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744\`
- \`actions/checkout@v4\` → \`actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5\`

### \`actions/setup-node@v3\` (GitHub-owned — allowed but not pinned)

GitHub's official action for installing a specific Node.js version on the runner. Same issue as \`checkout\` — allowed by policy but used a floating tag.

**Fix:** Pinned to its exact commit SHA:
- \`actions/setup-node@v3\` → \`actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610\`

### \`lee-dohm/no-response@v0.5.0\` in \`noresponse.yml\` (third-party — fully blocked)

This action automatically closes GitHub issues that have been labelled \`question\` but received no response from the author after 30 days. It runs on a daily cron schedule and on new issue comments.

It is a third-party action (not GitHub-owned) and therefore fully blocked by policy. Since this is a housekeeping feature with no impact on releases or CI correctness, **the \`noresponse.yml\` workflow was disabled** by replacing its trigger with \`workflow_dispatch\` (manual only, never fires automatically), preserving the file in case it is ever replaced with a compliant alternative.

## Changes in this PR

| File | Change |
|---|---|
| \`.github/workflows/on-merge-main.yml\` | Replace \`changesets/action@v1\` with shell script; pin \`actions/checkout\` and \`actions/setup-node\` to full SHAs |
| \`.github/workflows/nodejs.yml\` | Pin \`actions/checkout\` and \`actions/setup-node\` to full SHAs |
| \`.github/workflows/noresponse.yml\` | Disable automatic triggers (blocked third-party action) |

## Test plan

- [ ] Merge this PR to \`main\`
- [ ] Verify the "Merge to main" workflow starts successfully (no \`startup_failure\`)
- [ ] Verify a "chore: version packages" PR is opened for the pending node24 changeset from #555
