### PR TITLE
FNA-1289: update GitHub Actions runners to enterprise-approved labels

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [windows-latest-large, ubuntu-latest-large]
         node-version: [ lts/-1, lts/*]
 
     steps:

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     name: Run release work
     needs: tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Jira: https://twilio-engineering.atlassian.net/browse/FNA-1289

## Summary

GitHub-hosted runners (`ubuntu-latest`, `windows-latest`, `macos-latest`) are locked down across all Twilio GitHub organizations. Public repos must now use the new enterprise-approved runner labels.

This PR updates both workflow files to use the approved labels:

| Before | After |
|---|---|
| `ubuntu-latest` | `ubuntu-latest-large` |
| `windows-latest` | `windows-latest-large` |
| `macos-latest` | dropped (see below) |

**macOS:** `macos-latest-large` is not yet available in the enterprise runner group. The macOS matrix entry has been removed temporarily until it is supported.

## Context

This is the root cause of queued jobs seen recently, e.g. #559.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Verify the "Merge to main" workflow starts and jobs are picked up by runners (not stuck in queue)
- [ ] Restore `macos-latest-large` to the matrix once it is available